### PR TITLE
bugfix(lint): prevents showResult from running in disabled

### DIFF
--- a/esdoc-lint-plugin/src/Plugin.js
+++ b/esdoc-lint-plugin/src/Plugin.js
@@ -38,6 +38,8 @@ class Plugin {
   }
 
   onComplete() {
+    if (!this._option.enable) return;
+
     this._showResult();
   }
 


### PR DESCRIPTION
`this._showResult` attempts to iterate over `this._results`, which doesn't exist if the plugin is disabled and throws an error. This prevents that from happening.