### PR TITLE
experiment(modules): Refactor to a more module oriented structure

### DIFF
--- a/esdoc-publish-html-plugin/package.json
+++ b/esdoc-publish-html-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "esdoc-publish-html-plugin",
+  "name": "esdoc-publish-module-html-plugin",
   "version": "0.0.12",
   "description": "A publish HTML plugin for ESDoc",
   "author": "h13i32maru",

--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -188,24 +188,21 @@ export default class DocBuilder {
     allDocs.sort((a, b)=>{
       const filePathA = a.longname.split('~')[0];
       const filePathB = b.longname.split('~')[0];
-      const dirPathA = path.dirname(filePathA);
-      const dirPathB = path.dirname(filePathB);
       const kindA = a.interface ? 'interface' : a.kind;
       const kindB = b.interface ? 'interface' : b.kind;
-      if (dirPathA === dirPathB) {
+      if (filePathA === filePathB) {
         if (kindA === kindB) {
           return a.longname > b.longname ? 1 : -1;
         } else {
           return kindOrder[kindA] > kindOrder[kindB] ? 1 : -1;
         }
       } else {
-        return dirPathA > dirPathB ? 1 : -1;
+        return filePathA > filePathB ? 1 : -1;
       }
     });
     let lastDirPath = '.';
     ice.loop('doc', allDocs, (i, doc, ice)=>{
-      const filePath = doc.longname.split('~')[0].replace(/^.*?[/]/, '');
-      const dirPath = path.dirname(filePath);
+      const dirPath = doc.longname.replace(/\.[^/.]+$/, '');
       const kind = doc.interface ? 'interface' : doc.kind;
       const kindText = kind.charAt(0).toUpperCase();
       const kindClass = `kind-${kind}`;
@@ -559,9 +556,9 @@ export default class DocBuilder {
   _getOutputFileName(doc) {
     switch (doc.kind) {
       case 'variable':
-        return 'variable/index.html';
+        return `variable/${doc.memberof}.html`;
       case 'function':
-        return 'function/index.html';
+        return `function/${doc.memberof}.html`;
       case 'member': // fall
       case 'method': // fall
       case 'constructor': // fall

--- a/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
@@ -14,15 +14,28 @@ export default class SingleDocBuilder extends DocBuilder {
     for (const kind of kinds) {
       const docs = this._find({kind: kind});
       if (!docs.length) continue;
-      const fileName = this._getOutputFileName(docs[0]);
-      const baseUrl = this._getBaseUrl(fileName);
-      let title = kind.replace(/^(\w)/, (c)=> c.toUpperCase());
-      title = this._getTitle(title);
 
-      ice.load('content', this._buildSingleDoc(kind), IceCap.MODE_WRITE);
-      ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
-      ice.text('title', title, IceCap.MODE_WRITE);
-      writeFile(fileName, ice.html);
+      const moduleGroups = {};
+
+      for (const doc of docs) {
+        const docPath = doc.memberof;
+
+        moduleGroups[docPath] = moduleGroups[docPath] || [];
+        moduleGroups[docPath].push(doc);
+      }
+
+      for (const moduleGroup in moduleGroups) {
+        const docs = moduleGroups[moduleGroup];
+        const fileName = this._getOutputFileName(docs[0]);
+        const baseUrl = this._getBaseUrl(fileName);
+        let title = kind.replace(/^(\w)/, c => c.toUpperCase());
+        title = this._getTitle(title);
+
+        ice.load('content', this._buildSingleDoc(kind, docs), IceCap.MODE_WRITE);
+        ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
+        ice.text('title', title, IceCap.MODE_WRITE);
+        writeFile(fileName, ice.html);
+      }
     }
   }
 
@@ -32,12 +45,46 @@ export default class SingleDocBuilder extends DocBuilder {
    * @returns {string} html of single output
    * @private
    */
-  _buildSingleDoc(kind) {
+  _buildSingleDoc(kind, docs) {
     const title = kind.replace(/^(\w)/, (c)=> c.toUpperCase());
     const ice = new IceCap(this._readTemplate('single.html'));
+
+    const link = this._buildFileDocLinkHTML(docs[0], docs[0].importPath);
+    ice.into('importPath', `import * from '${link}'`, (code, ice)=>{
+      ice.load('importPathCode', code);
+    });
+
     ice.text('title', title);
-    ice.load('summaries', this._buildSummaryHTML(null, kind, 'Summary'), 'append');
-    ice.load('details', this._buildDetailHTML(null, kind, ''));
+    ice.load('summaries', this._buildSummaryHTML(docs, kind, 'Summary'), 'append');
+    ice.load('details', this._buildDetailHTML(docs, kind, ''));
     return ice.html;
+  }
+
+  _buildSummaryHTML(docs, kind, title, isStatic = true) {
+    let html = '';
+    let prefix = '';
+
+    if (docs[0].static) prefix = 'Static ';
+    const _title = `${prefix}${kind} ${title}`;
+
+    const result = this._buildSummaryDoc(docs, _title);
+    if (result) {
+      html += result.html;
+    }
+
+    return html;
+  }
+
+  _buildDetailHTML(docs, kind, title, isStatic = true) {
+    let html = '';
+    let prefix = '';
+
+    if (docs[0].static) prefix = 'Static ';
+    const _title = `${prefix}${kind} ${title}`;
+
+    const result = this._buildDetailDocs(docs, _title);
+    if (result) html += result.html;
+
+    return html;
   }
 }

--- a/esdoc-publish-html-plugin/src/Builder/template/nav.html
+++ b/esdoc-publish-html-plugin/src/Builder/template/nav.html
@@ -1,5 +1,8 @@
 <div>
   <ul>
-    <li data-ice="doc"><a data-ice="dirPath" class="nav-dir-path"></a><span data-ice="kind"></span><span data-ice="name"></span></li>
+    <li data-ice="doc">
+      <a data-ice="dirPath" class="nav-dir-path"></a>
+      <span data-ice="kind"></span><span data-ice="name"></span>
+    </li>
   </ul>
 </div>

--- a/esdoc-publish-html-plugin/src/Builder/template/single.html
+++ b/esdoc-publish-html-plugin/src/Builder/template/single.html
@@ -1,3 +1,9 @@
-<h1 data-ice="title"></h1>
-<div data-ice="summaries"></div>
-<div data-ice="details"></div>
+<div class="header-notice">
+  <div data-ice="importPath" class="import-path"><pre class="prettyprint"><code data-ice="importPathCode"></code></pre></div>
+</div>
+
+<div class="self-detail detail">
+  <h1 data-ice="title"></h1>
+  <div data-ice="summaries"></div>
+  <div data-ice="details"></div>
+</div>


### PR DESCRIPTION
I'm opening this PR for discussion purposes only.

ESDoc is pretty amazing as is, @h13i32maru has done an incredible job with the overall architecture and the plugin system. That said, I feel like the standard HTML publishing plugin could be a bit more flexible. The opinionated layout is great as a basis, but it doesn't work for every package.

ES6 is fundamentally module based, which means there are lots of libraries (like Lodash for instance) which consist entirely of a flat set of modules that export large numbers of functions. It would be nice to be able to have the top level navigation reflect this, and to generate multiple Function/Variable pages (one per module) in these cases.

I'm not sure if this should be the responsibility of the `esdoc-publish-html-plugin`, but from this PR you can see that it wouldn't require many changes at all. It could be an option, or maybe we make the plugin more extensible, so other plugins could extend it to change the structure when necessary.