### PR TITLE
esdoc-coverage-plugin: Add coverage kind option

### DIFF
--- a/esdoc-coverage-plugin/README.md
+++ b/esdoc-coverage-plugin/README.md
@@ -10,12 +10,20 @@ npm install esdoc-coverage-plugin
   "source": "./src",
   "destination": "./doc",
   "plugins": [
-    {"name": "esdoc-coverage-plugin", "option": {"enable": true}}
+    {
+      "name": "esdoc-coverage-plugin", 
+      "option": {
+        "enable": true,
+        "kind": ["class", "method", "member", "get", "set", "constructor", "function", "variable"]
+      }
+    }
   ]
 }
 ```
 
 `enable` is default `true`.
+
+`kind` is default `["class", "method", "member", "get", "set", "constructor", "function", "variable"]`.
 
 ## LICENSE
 MIT

--- a/esdoc-coverage-plugin/src/Plugin.js
+++ b/esdoc-coverage-plugin/src/Plugin.js
@@ -10,8 +10,9 @@ class Plugin {
     const option = ev.data.option || {};
     if (!('enable' in option)) option.enable = true;
     if (!option.enable) return;
-
-    const docs = this._docs.filter(v => ['class', 'method', 'member', 'get', 'set', 'constructor', 'function', 'variable'].includes(v.kind));
+    if (!('kind' in option)) option.kind = ['class', 'method', 'member', 'get', 'set', 'constructor', 'function', 'variable'];
+    if (!option.kind) return;
+    const docs = this._docs.filter(v => option.kind.includes(v.kind));
     const expectCount = docs.length;
     let actualCount = 0;
     const files = {};


### PR DESCRIPTION
Not include in coverage such as `constructor`, `variable`, etc..
[esdoc-coverage-plugin](https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-coverage-plugin) add coverage kind option.