### PR TITLE
feat: support for custom templates via option (esdoc-publish-html-plugin)

### DIFF
--- a/esdoc-publish-html-plugin/README.md
+++ b/esdoc-publish-html-plugin/README.md
@@ -15,6 +15,11 @@ npm install esdoc-publish-html-plugin
 }
 ```
 
+To use a custom template (ex `my-template` placed in the working directory):
+```json
+    {"name": "esdoc-publish-html-plugin", "option": {"template": "my-template"}}
+```
+
 ## LICENSE
 MIT
 

--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -13,9 +13,11 @@ import NPMUtil from 'esdoc/out/src/Util/NPMUtil.js';
 export default class DocBuilder {
   /**
    * create instance.
+   * @param {String} template - template absolute path
    * @param {Taffy} data - doc object database.
    */
-  constructor(data, tags) {
+  constructor(template, data, tags) {
+    this._template = template;
     this._data = data;
     this._tags = tags;
     new DocResolver(this).resolve();
@@ -136,7 +138,7 @@ export default class DocBuilder {
    * @protected
    */
   _readTemplate(fileName) {
-    const filePath = path.resolve(__dirname, `./template/${fileName}`);
+    const filePath = path.resolve(this._template, `./${fileName}`);
     return fs.readFileSync(filePath, {encoding: 'utf-8'});
   }
 

--- a/esdoc-publish-html-plugin/src/Builder/StaticFileBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/StaticFileBuilder.js
@@ -6,8 +6,8 @@ import DocBuilder from './DocBuilder.js';
  */
 export default class StaticFileBuilder extends DocBuilder {
   exec(writeFile, copyDir) {
-    copyDir(path.resolve(__dirname, './template/css'), './css');
-    copyDir(path.resolve(__dirname, './template/script'), './script');
-    copyDir(path.resolve(__dirname, './template/image'), './image');
+    copyDir(path.resolve(this._template, 'css'), './css');
+    copyDir(path.resolve(this._template, 'script'), './script');
+    copyDir(path.resolve(this._template, 'image'), './image');
   }
 }

--- a/esdoc-publish-html-plugin/src/Plugin.js
+++ b/esdoc-publish-html-plugin/src/Plugin.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import {taffy} from 'taffydb';
 import IceCap from 'ice-cap';
 import DocBuilder from './Builder/DocBuilder';
@@ -20,6 +21,9 @@ class Plugin {
 
   onPublish(ev) {
     this._option = ev.data.option || {};
+    this._template = typeof this._option.template === 'string'
+      ? path.resolve(process.cwd(), this._option.template)
+      : path.resolve(__dirname, './Builder/template');
     this._exec(this._docs, ev.data.writeFile, ev.data.copyDir, ev.data.readFile);
   }
 
@@ -29,8 +33,8 @@ class Plugin {
     const data = taffy(tags);
 
     //bad hack: for other plugin uses builder.
-    DocBuilder.createDefaultBuilder = function() {
-      return new DocBuilder(data, tags);
+    DocBuilder.createDefaultBuilder = () => {
+      return new DocBuilder(this._template, data, tags);
     };
 
     let coverage = null;
@@ -40,20 +44,20 @@ class Plugin {
       // nothing
     }
 
-    new IdentifiersDocBuilder(data, tags).exec(writeFile, copyDir);
-    new IndexDocBuilder(data, tags).exec(writeFile, copyDir);
-    new ClassDocBuilder(data, tags).exec(writeFile, copyDir);
-    new SingleDocBuilder(data, tags).exec(writeFile, copyDir);
-    new FileDocBuilder(data, tags).exec(writeFile, copyDir);
-    new StaticFileBuilder(data, tags).exec(writeFile, copyDir);
-    new SearchIndexBuilder(data, tags).exec(writeFile, copyDir);
-    new SourceDocBuilder(data, tags).exec(writeFile, copyDir, coverage);
-    new ManualDocBuilder(data, tags).exec(writeFile, copyDir, readFile);
+    new IdentifiersDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new IndexDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new ClassDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new SingleDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new FileDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new StaticFileBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new SearchIndexBuilder(this._template, data, tags).exec(writeFile, copyDir);
+    new SourceDocBuilder(this._template, data, tags).exec(writeFile, copyDir, coverage);
+    new ManualDocBuilder(this._template, data, tags).exec(writeFile, copyDir, readFile);
 
     const existTest = tags.find(tag => tag.kind.indexOf('test') === 0);
     if (existTest) {
-      new TestDocBuilder(data, tags).exec(writeFile, copyDir);
-      new TestFileDocBuilder(data, tags).exec(writeFile, copyDir);
+      new TestDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
+      new TestFileDocBuilder(this._template, data, tags).exec(writeFile, copyDir);
     }
   }
 }


### PR DESCRIPTION
Hi,

I've started using this as of recently (really great stuff), but needed to make custom templates. I noticed it was not a feature, so I added it :)

This patch allows for defining the `template` option that overrides the internal hard-coded path (joins with `process.cwd()`) so you can make your own templates.

**Edit**: This is for: esdoc-publish-html-plugin