### PR TITLE
feat(esdoc-publish-html-plugin): Add directory matching for SingleDocBuilder

### DIFF
--- a/esdoc-publish-html-plugin/src/Builder/ClassDocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/ClassDocBuilder.js
@@ -64,7 +64,7 @@ export default class ClassDocBuilder extends DocBuilder {
     ice.load('indirectImplemented', this._buildDocsLinkHTML(doc._custom_indirect_implemented, null, false, ', '), 'append');
 
     // self
-    ice.text('name', doc.name);
+    ice.text('name', this._getTitle(doc));
     ice.load('description', doc.description);
     ice.load('deprecated', this._buildDeprecatedHTML(doc));
     ice.load('experimental', this._buildExperimentalHTML(doc));

--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -567,7 +567,7 @@ export default class DocBuilder {
     if (!doc) return '';
 
     const filePath = doc.longname.split('~')[0].replace(/^.*?[/]/, '');
-    return _path2.default.dirname(filePath);
+    return path.dirname(filePath);
   }
 
   /**

--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -530,9 +530,13 @@ export default class DocBuilder {
         name = doc.kind;
       }
 
-      name = [...this._getPath(doc).split('/'), name]
-      .map((p) => p.replace(/\b(\w)/g, p => p.toUpperCase()))
-      .join(' / ');
+      //Capitalize?
+      if (!['file', 'testFile', 'test'].includes(doc.kind))
+      {
+        name = [...this._getPath(doc).split('/'), name]
+        .map((p) => p.replace(/\b(\w)/g, p => p.toUpperCase()))
+        .join(' / ');
+      }
     }
 
     if (name) {

--- a/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
@@ -37,9 +37,9 @@ export default class SingleDocBuilder extends DocBuilder {
         let title = paths.join(' / ').replace(/\b(\w)/g, c => c.toUpperCase());
         title = this._getTitle(title);
 
-        ice.load('content', this._buildSingleDoc(docs, kind, title), IceCap.default.MODE_WRITE);
-        ice.attr('baseUrl', 'href', this._getBaseUrl(docPath), IceCap.default.MODE_WRITE);
-        ice.text('title', title, IceCap.default.MODE_WRITE);
+        ice.load('content', this._buildSingleDoc(docs, kind, title), IceCap.MODE_WRITE);
+        ice.attr('baseUrl', 'href', this._getBaseUrl(docPath), IceCap.MODE_WRITE);
+        ice.text('title', title, IceCap.MODE_WRITE);
         writeFile(docPath, ice.html);
       }
     }
@@ -54,7 +54,7 @@ export default class SingleDocBuilder extends DocBuilder {
    * @private
    */
   _buildSingleDoc(docs, kind, title) {
-    const ice = new IceCap.default(this._readTemplate('single.html'));
+    const ice = new IceCap(this._readTemplate('single.html'));
     ice.text('title', title);
 
     docs.forEach((doc) => {

--- a/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
@@ -14,30 +14,54 @@ export default class SingleDocBuilder extends DocBuilder {
     for (const kind of kinds) {
       const docs = this._find({kind: kind});
       if (!docs.length) continue;
-      const fileName = this._getOutputFileName(docs[0]);
-      const baseUrl = this._getBaseUrl(fileName);
-      let title = kind.replace(/^(\w)/, (c)=> c.toUpperCase());
-      title = this._getTitle(title);
 
-      ice.load('content', this._buildSingleDoc(kind), IceCap.MODE_WRITE);
-      ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
-      ice.text('title', title, IceCap.MODE_WRITE);
-      writeFile(fileName, ice.html);
+      //Organize by paths
+      let docPaths = {};
+
+      //Filter each doc by its path
+      docs.forEach((doc) => {
+        const fileName = this._getOutputFileName(doc);
+
+        if (!docPaths[fileName]) docPaths[fileName] = [doc];
+        else docPaths[fileName].push(doc);
+      });
+
+      //Build each output file
+      for (const docPath in docPaths) {
+        const docs = docPaths[docPath];
+
+        //Build the title from path
+        let paths = docPath.split('/').filter(function(path){
+          return !path.match(/(^\.$)|(index\.html$)/gi);
+        });
+        let title = paths.join(' / ').replace(/\b(\w)/g, c => c.toUpperCase());
+        title = this._getTitle(title);
+
+        ice.load('content', this._buildSingleDoc(docs, kind, title), IceCap.default.MODE_WRITE);
+        ice.attr('baseUrl', 'href', this._getBaseUrl(docPath), IceCap.default.MODE_WRITE);
+        ice.text('title', title, IceCap.default.MODE_WRITE);
+        writeFile(docPath, ice.html);
+      }
     }
   }
 
   /**
    * build single output.
+   * @param {DocObject[]} docs - target docs.
    * @param {string} kind - target kind property.
+   * @param {string} title - output title
    * @returns {string} html of single output
    * @private
    */
-  _buildSingleDoc(kind) {
-    const title = kind.replace(/^(\w)/, (c)=> c.toUpperCase());
-    const ice = new IceCap(this._readTemplate('single.html'));
+  _buildSingleDoc(docs, kind, title) {
+    const ice = new IceCap.default(this._readTemplate('single.html'));
     ice.text('title', title);
-    ice.load('summaries', this._buildSummaryHTML(null, kind, 'Summary'), 'append');
-    ice.load('details', this._buildDetailHTML(null, kind, ''));
+
+    docs.forEach((doc) => {
+      ice.load('summaries', this._buildSummaryHTML(doc, kind, 'Summary', true, this._getPath(doc)), 'append');
+      ice.load('details', this._buildDetailHTML(doc, kind, '', true, this._getPath(doc)), 'append');
+    });
+
     return ice.html;
   }
 }

--- a/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/SingleDocBuilder.js
@@ -22,24 +22,22 @@ export default class SingleDocBuilder extends DocBuilder {
       docs.forEach((doc) => {
         const docPath = this._getPath(doc);
         const outPath = this._getOutputFileName(doc);
+        const docTitle = this._getTitle(doc);
 
-        if (!docPaths[docPath]) docPaths[docPath] = outPath;
+        if (!docPaths[docPath]) docPaths[docPath] = {
+          outPath,
+          docTitle
+        };
       });
 
       //Build each output file
       for (const docPath in docPaths) {
-        const outPath = docPaths[docPath];
+        const docObj = docPaths[docPath];
 
-        // Build the title from the path
-        const pathTitle = [...docPath.split('/'), kind]
-          .map((p) => p.replace(/\b(\w)/g, p => p.toUpperCase()))
-          .join(' / ');
-        let title = this._getTitle(pathTitle);
-
-        ice.load('content', this._buildSingleDoc(docPath, kind, title), IceCap.MODE_WRITE);
-        ice.attr('baseUrl', 'href', this._getBaseUrl(outPath), IceCap.MODE_WRITE);
-        ice.text('title', title, IceCap.MODE_WRITE);
-        writeFile(outPath, ice.html);
+        ice.load('content', this._buildSingleDoc(docPath, kind, docObj.docTitle), IceCap.MODE_WRITE);
+        ice.attr('baseUrl', 'href', this._getBaseUrl(docObj.outPath), IceCap.MODE_WRITE);
+        ice.text('title', docObj.docTitle, IceCap.MODE_WRITE);
+        writeFile(docObj.outPath, ice.html);
       }
     }
   }

--- a/esdoc-publish-html-plugin/src/Plugin.js
+++ b/esdoc-publish-html-plugin/src/Plugin.js
@@ -12,6 +12,7 @@ import SourceDocBuilder from './Builder/SourceDocBuilder.js';
 import TestDocBuilder from './Builder/TestDocBuilder.js';
 import TestFileDocBuilder from './Builder/TestFileDocBuilder.js';
 import ManualDocBuilder from './Builder/ManualDocBuilder.js';
+import PluginOptions from './PluginOptions';
 
 class Plugin {
   onHandleDocs(ev) {
@@ -19,18 +20,26 @@ class Plugin {
   }
 
   onPublish(ev) {
-    this._option = ev.data.option || {};
+    this._options = ev.data.option || {};
     this._exec(this._docs, ev.data.writeFile, ev.data.copyDir, ev.data.readFile);
   }
 
   _exec(tags, writeFile, copyDir, readFile) {
-    IceCap.debug = !!this._option.debug;
+    //Copy options
+    for (var key in PluginOptions) {
+      //Mismatch?
+      if (typeof this._options[key] !== typeof PluginOptions[key]) {
+        this._options[key] = PluginOptions[key];
+      }
+    }
+
+    IceCap.debug = !!this._options.debug;
 
     const data = taffy(tags);
 
     //bad hack: for other plugin uses builder.
     DocBuilder.createDefaultBuilder = function() {
-      return new DocBuilder(data, tags);
+      return new DocBuilder(data, tags, this._options);
     };
 
     let coverage = null;
@@ -40,20 +49,20 @@ class Plugin {
       // nothing
     }
 
-    new IdentifiersDocBuilder(data, tags).exec(writeFile, copyDir);
-    new IndexDocBuilder(data, tags).exec(writeFile, copyDir);
-    new ClassDocBuilder(data, tags).exec(writeFile, copyDir);
-    new SingleDocBuilder(data, tags).exec(writeFile, copyDir);
-    new FileDocBuilder(data, tags).exec(writeFile, copyDir);
-    new StaticFileBuilder(data, tags).exec(writeFile, copyDir);
-    new SearchIndexBuilder(data, tags).exec(writeFile, copyDir);
-    new SourceDocBuilder(data, tags).exec(writeFile, copyDir, coverage);
-    new ManualDocBuilder(data, tags).exec(writeFile, copyDir, readFile);
+    new IdentifiersDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new IndexDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new ClassDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new SingleDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new FileDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new StaticFileBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new SearchIndexBuilder(data, tags, this._options).exec(writeFile, copyDir);
+    new SourceDocBuilder(data, tags, this._options).exec(writeFile, copyDir, coverage);
+    new ManualDocBuilder(data, tags, this._options).exec(writeFile, copyDir, readFile);
 
     const existTest = tags.find(tag => tag.kind.indexOf('test') === 0);
     if (existTest) {
-      new TestDocBuilder(data, tags).exec(writeFile, copyDir);
-      new TestFileDocBuilder(data, tags).exec(writeFile, copyDir);
+      new TestDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
+      new TestFileDocBuilder(data, tags, this._options).exec(writeFile, copyDir);
     }
   }
 }

--- a/esdoc-publish-html-plugin/src/PluginOptions.js
+++ b/esdoc-publish-html-plugin/src/PluginOptions.js
@@ -1,0 +1,5 @@
+//Default plugin options
+module.exports = {
+  debug: false,
+  organizePaths: false
+};

--- a/esdoc-publish-html-plugin/src/PluginOptions.js
+++ b/esdoc-publish-html-plugin/src/PluginOptions.js
@@ -1,5 +1,5 @@
 //Default plugin options
 module.exports = {
   debug: false,
-  organizePaths: false
+  organizePaths: true
 };

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/AbstractTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/AbstractTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {DocBuilder} */
 describe('TestAbstractDefinition:', ()=> {
-  const doc = readDoc('class/src/Abstract/Definition.js~TestAbstractDefinition.html');
+  const doc = readDoc('class/src/Abstract/Definition.js~TestAbstractDefinition.html', 'Abstract');
 
   /** @test {DocBuilder#_buildSummaryDoc} */
   it('has abstract method in summary.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/AbstractTest/OverrideTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/AbstractTest/OverrideTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {DocBuilder} */
 describe('TestAbstractOverrideDefinition:', ()=> {
-  const doc = readDoc('class/src/Abstract/Override.js~TestAbstractOverride.html');
+  const doc = readDoc('class/src/Abstract/Override.js~TestAbstractOverride.html', 'Abstract');
 
   /** @test {DocBuilder#_buildOverrideMethod} */
   it('has override description in summary.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#_$async} */
 describe('testAsyncFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Async/function/index.html');
 
   describe('in summary', ()=> {
     it('has async mark', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#_$async} */
 describe('testAsyncFunction', ()=> {
-  const doc = readDoc('Async/function/index.html');
+  const doc = readDoc('function/index.html', 'Async');
 
   describe('in summary', ()=> {
     it('has async mark', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/AsyncTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {MethodDoc#_$async} */
 describe('TestAsyncMethod', ()=> {
-  const doc = readDoc('class/src/Async/Method.js~TestAsyncMethod.html');
+  const doc = readDoc('class/src/Async/Method.js~TestAsyncMethod.html', 'Async');
 
   describe('in summary', ()=> {
     it('has async mark.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ClassPropertyTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ClassPropertyTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDocBuilder} */
 describe('TestClassPropertyDefinition:', ()=> {
-  const doc = readDoc('class/src/ClassProperty/Definition.js~TestClassPropertyDefinition.html');
+  const doc = readDoc('class/src/ClassProperty/Definition.js~TestClassPropertyDefinition.html', 'ClassProperty');
 
   /** @test {ClassDocBuilder#_buildClassDoc} */
   describe('in summary', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ClassTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ClassTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDocBuilder} */
 describe('TestClassDefinition:', ()=> {
-  const doc = readDoc('class/src/Class/Definition.js~TestClassDefinition.html');
+  const doc = readDoc('class/src/Class/Definition.js~TestClassDefinition.html', 'Class');
 
   /** @test {DocBuilder#_getTitle} */
   describe('in title:', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ComputedTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ComputedTest/MethodTest.js
@@ -3,21 +3,21 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {MethodDoc#@_name} */
 describe('TestComputedMethod:', ()=> {
-  const doc = readDoc('class/src/Computed/Method.js~TestComputedMethod.html');
+  const doc = readDoc('class/src/Computed/Method.js~TestComputedMethod.html', 'Computed');
 
   describe('in summary:', ()=>{
     it('has computed methods.', ()=> {
       find(doc, '[data-ice="summary"]', (doc)=>{
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-['foo']"]`,            `['foo']`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[Symbol.iterator]"]`,  `[Symbol.iterator]`);
-        assert.includes(doc, '[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[`${ foo }`]"]',       '[`${ foo }`]');
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo + bar]"]`,        `[foo + bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo()]"]`,            `[foo()]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar()]"]`,        `[foo.bar()]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar.baz]"]`,      `[foo.bar.baz]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar]"]`,          `[foo.bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.p + bar]"]`,      `[foo.p + bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo]"]`,              `[foo]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-['foo']"]`,            `['foo']`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[Symbol.iterator]"]`,  `[Symbol.iterator]`);
+        assert.includes(doc, '[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[`${ foo }`]"]',       '[`${ foo }`]');
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo + bar]"]`,        `[foo + bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo()]"]`,            `[foo()]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar()]"]`,        `[foo.bar()]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar.baz]"]`,      `[foo.bar.baz]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.bar]"]`,          `[foo.bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo.p + bar]"]`,      `[foo.p + bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Method.js~TestComputedMethod.html#instance-method-[foo]"]`,              `[foo]`);
       });
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ComputedTest/PropertyTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ComputedTest/PropertyTest.js
@@ -3,21 +3,21 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {MemberDoc#@_name} */
 describe('TestComputedProperty:', ()=> {
-  const doc = readDoc('class/src/Computed/Property.js~TestComputedProperty.html');
+  const doc = readDoc('class/src/Computed/Property.js~TestComputedProperty.html', 'Computed');
 
   describe('in summary:', ()=>{
     it('has computed properties.', ()=> {
       find(doc, '[data-ice="memberSummary"]', (doc)=>{
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-['foo']"]`,             `['foo']`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[Symbol.iterator]"]`,  `[Symbol.iterator]`);
-        assert.includes(doc, '[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[`${ foo }`]"]',       '[`${ foo }`]');
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo + bar]"]`,        `[foo + bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo()]"]`,            `[foo()]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar()]"]`,        `[foo.bar()]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar.baz]"]`,      `[foo.bar.baz]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar]"]`,          `[foo.bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.p + bar]"]`,      `[foo.p + bar]`);
-        assert.includes(doc, `[href="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo]"]`,              `[foo]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-['foo']"]`,             `['foo']`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[Symbol.iterator]"]`,  `[Symbol.iterator]`);
+        assert.includes(doc, '[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[`${ foo }`]"]',       '[`${ foo }`]');
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo + bar]"]`,        `[foo + bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo()]"]`,            `[foo()]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar()]"]`,        `[foo.bar()]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar.baz]"]`,      `[foo.bar.baz]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.bar]"]`,          `[foo.bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo.p + bar]"]`,      `[foo.p + bar]`);
+        assert.includes(doc, `[href$="class/src/Computed/Property.js~TestComputedProperty.html#instance-member-[foo]"]`,              `[foo]`);
       });
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DecoratorTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DecoratorTest/DefinitionTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
  * @test {DocBuilder#_buildDetailDocs}
  */
 describe('TestDecoratorDefinition:', ()=> {
-  const doc = readDoc('class/src/Decorator/Definition.js~TestDecoratorDefinition.html');
+  const doc = readDoc('class/src/Decorator/Definition.js~TestDecoratorDefinition.html', 'Decorator');
 
   it('has decorator at class.', ()=>{
     find(doc, '[data-ice="content"] .self-detail', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@deprecated} */
 describe('TestDeprecatedClass:', ()=> {
-  const doc = readDoc('class/src/Deprecated/Class.js~TestDeprecatedClass.html');
+  const doc = readDoc('class/src/Deprecated/Class.js~TestDeprecatedClass.html', 'Deprecated');
 
   describe('in self detail:', ()=> {
     it('has deprecated message of self.', ()=> {
@@ -12,12 +12,12 @@ describe('TestDeprecatedClass:', ()=> {
 
   describe('in summary:', ()=> {
     it('has deprecated message of member and method.', ()=> {
-      find(doc, '[data-ice="summary"] [href="class/src/Deprecated/Class.js~TestDeprecatedClass.html#instance-member-p1"]', (doc)=> {
+      find(doc, '[data-ice="summary"] [href$="class/src/Deprecated/Class.js~TestDeprecatedClass.html#instance-member-p1"]', (doc)=> {
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this member was deprecated.');
       });
 
-      find(doc, '[data-ice="summary"] [href="class/src/Deprecated/Class.js~TestDeprecatedClass.html#instance-method-method1"]', (doc)=> {
+      find(doc, '[data-ice="summary"] [href$="class/src/Deprecated/Class.js~TestDeprecatedClass.html#instance-method-method1"]', (doc)=> {
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this method was deprecated.');
       });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/FunctionTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@deprecated} */
 describe('testDeprecatedFunction:', ()=> {
-  const doc = readDoc('Deprecated/function/index.html');
+  const doc = readDoc('function/index.html', 'Deprecated');
 
   describe('in summary', ()=> {
     it('has deprecated message.', ()=> {
-      find(doc, '[data-ice="summary"] [href="Deprecated/function/index.html#static-function-testDeprecatedFunction"]', (doc)=>{
+      find(doc, '[data-ice="summary"] [href$="function/index.html#static-function-testDeprecatedFunction"]', (doc)=>{
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this function was deprecated.');
       });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/FunctionTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@deprecated} */
 describe('testDeprecatedFunction:', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Deprecated/function/index.html');
 
   describe('in summary', ()=> {
     it('has deprecated message.', ()=> {
-      find(doc, '[data-ice="summary"] [href="function/index.html#static-function-testDeprecatedFunction"]', (doc)=>{
+      find(doc, '[data-ice="summary"] [href="Deprecated/function/index.html#static-function-testDeprecatedFunction"]', (doc)=>{
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this function was deprecated.');
       });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/VariableTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@deprecated} */
 describe('testDeprecatedVariable:', ()=> {
-  const doc = readDoc('Deprecated/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Deprecated');
 
   describe('in summary', ()=> {
     it('has deprecated message.', ()=> {
-      find(doc, '[data-ice="summary"] [href="Deprecated/variable/index.html#static-variable-testDeprecatedVariable"]', (doc)=>{
+      find(doc, '[data-ice="summary"] [href$="variable/index.html#static-variable-testDeprecatedVariable"]', (doc)=>{
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this variable was deprecated.');
       });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DeprecatedTest/VariableTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@deprecated} */
 describe('testDeprecatedVariable:', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Deprecated/variable/index.html');
 
   describe('in summary', ()=> {
     it('has deprecated message.', ()=> {
-      find(doc, '[data-ice="summary"] [href="variable/index.html#static-variable-testDeprecatedVariable"]', (doc)=>{
+      find(doc, '[data-ice="summary"] [href="Deprecated/variable/index.html#static-variable-testDeprecatedVariable"]', (doc)=>{
         doc = doc.parents('[data-ice="target"]');
         assert.includes(doc, '[data-ice="deprecated"]', 'this variable was deprecated.');
       });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('TestDescClass', ()=> {
-  const doc = readDoc('class/src/Desc/Class.js~TestDescClass.html');
+  const doc = readDoc('class/src/Desc/Class.js~TestDescClass.html', 'Desc');
 
   describe('in self detail', ()=> {
     it('has desc.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('testDescFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Desc/function/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('testDescFunction', ()=> {
-  const doc = readDoc('Desc/function/index.html');
+  const doc = readDoc('function/index.html', 'Desc');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/MarkdownTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/MarkdownTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('TestDescMarkdown:', ()=> {
-  const doc = readDoc('class/src/Desc/Markdown.js~TestDescMarkdown.html');
+  const doc = readDoc('class/src/Desc/Markdown.js~TestDescMarkdown.html', 'Desc');
 
   describe('in self detail', ()=> {
     it('has markdown desc.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/MultiLineTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/MultiLineTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('TestDescMultiLine:', ()=> {
-  const doc = readDoc('class/src/Desc/MultiLine.js~TestDescMultiLine.html');
+  const doc = readDoc('class/src/Desc/MultiLine.js~TestDescMultiLine.html', 'Desc');
 
   describe('in summary', ()=> {
     it('has first sentence desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('testDescVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Desc/variable/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DescTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('testDescVariable', ()=> {
-  const doc = readDoc('Desc/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Desc');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DestructuringTest/ArrayTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DestructuringTest/ArrayTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@param} */
 describe('TestDestructuringArray', ()=> {
-  const doc = readDoc('class/src/Destructuring/Array.js~TestDestructuringArray.html');
+  const doc = readDoc('class/src/Destructuring/Array.js~TestDestructuringArray.html', 'Destructuring');
 
   describe('in summary', ()=> {
     it('has array destructuring', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DestructuringTest/ObjectTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DestructuringTest/ObjectTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@param} */
 describe('TestDestructuringObject', ()=> {
-  const doc = readDoc('class/src/Destructuring/Object.js~TestDestructuringObject.html');
+  const doc = readDoc('class/src/Destructuring/Object.js~TestDestructuringObject.html', 'Destructuring');
 
   describe('in summary', ()=> {
     it('has object destructuring', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/DuplicationTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/DuplicationTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveDuplication} */
 describe('TestDuplicationDefinition', ()=> {
-  const doc = readDoc('class/src/Duplication/Definition.js~TestDuplicationDefinition.html');
+  const doc = readDoc('class/src/Duplication/Definition.js~TestDuplicationDefinition.html', 'Duplication');
 
   describe('in summary', ()=> {
     it('has setter/getter/method.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@emits} */
 describe('testEmitsFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Emits/function/index.html');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@emits} */
 describe('testEmitsFunction', ()=> {
-  const doc = readDoc('Emits/function/index.html');
+  const doc = readDoc('function/index.html', 'Emits');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/EmitsTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@emits} */
 describe('TestEmitsMethod', ()=> {
-  const doc = readDoc('class/src/Emits/Method.js~TestEmitsMethod.html');
+  const doc = readDoc('class/src/Emits/Method.js~TestEmitsMethod.html', 'Emits');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/CaptionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/CaptionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('TestExampleCaption', ()=> {
-  const doc = readDoc('class/src/Example/Caption.js~TestExampleCaption.html');
+  const doc = readDoc('class/src/Example/Caption.js~TestExampleCaption.html', 'Example');
 
   describe('in self detail', ()=> {
     it('has caption of example.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('TestExampleClass', ()=> {
-  const doc = readDoc('class/src/Example/Class.js~TestExampleClass.html');
+  const doc = readDoc('class/src/Example/Class.js~TestExampleClass.html', 'Example');
 
   describe('in self detail', ()=> {
     it('has example.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('testExampleFunction', ()=> {
-  const doc = readDoc('Example/function/index.html');
+  const doc = readDoc('function/index.html', 'Example');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('testExampleFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Example/function/index.html');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('testDescVariable', ()=> {
-  const doc = readDoc('Example/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Example');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExamleTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@example} */
 describe('testDescVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Example/variable/index.html');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@experimental} */
 describe('TestExperimentalClass', ()=> {
-  const doc = readDoc('class/src/Experimental/Class.js~TestExperimentalClass.html');
+  const doc = readDoc('class/src/Experimental/Class.js~TestExperimentalClass.html', 'Experimental');
 
   describe('in self detail', ()=> {
     it('has desc.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@experimental} */
 describe('testExperimentalFunction', ()=> {
-  const doc = readDoc('Experimental/function/index.html');
+  const doc = readDoc('function/index.html', 'Experimental');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@experimental} */
 describe('testExperimentalFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Experimental/function/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@experimental} */
 describe('testExperimentalVariable', ()=> {
-  const doc = readDoc('Experimental/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Experimental');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExperimentalTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@experimental} */
 describe('testExperimentalVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Experimental/variable/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExponentialOperatorTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExponentialOperatorTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {ESParser} */
 describe('TestExponentiationOperatorDefinition', ()=> {
-  const doc = readDoc('class/src/ExponentiationOperator/Definition.js~TestExponentiationOperatorDefinition.html');
+  const doc = readDoc('class/src/ExponentiationOperator/Definition.js~TestExponentiationOperatorDefinition.html', 'ExponentiationOperator');
 
   describe('in self detail', ()=> {
     it('has desc.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert} from './../../util.js';
 
 /** @test {ClassDoc#@_name} */
 describe('TestExportAnonymousClass', ()=> {
-  const doc = readDoc('class/src/Export/AnonymousClass.js~AnonymousClass.html');
+  const doc = readDoc('class/src/Export/AnonymousClass.js~AnonymousClass.html', 'Export');
 
   describe('in self detail', ()=> {
     it('is named with anonymous.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousFunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousFunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('testExportAnonymousFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Export/function/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousFunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/AnonymousFunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('testExportAnonymousFunction', ()=> {
-  const doc = readDoc('Export/function/index.html');
+  const doc = readDoc('function/index.html', 'Export');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ArrowFunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ArrowFunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export arrow function', ()=> {
-  const doc = readDoc('Export/function/index.html');
+  const doc = readDoc('function/index.html', 'Export');
 
   it('has default import path with direct arrow function definition.', ()=> {
     findParent(doc, '[id="static-function-ArrowFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ArrowFunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ArrowFunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export arrow function', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Export/function/index.html');
 
   it('has default import path with direct arrow function definition.', ()=> {
     findParent(doc, '[id="static-function-ArrowFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ClassIndirectDefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ClassIndirectDefaultTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert} from './../../util.js';
  */
 describe('test export class indirect default', ()=> {
   it('has default import path with indirect class definition.', ()=> {
-    const doc = readDoc('class/src/Export/ClassIndirectDefault.js~TestExportClassIndirectDefault.html');
+    const doc = readDoc('class/src/Export/ClassIndirectDefault.js~TestExportClassIndirectDefault.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import TestExportClassIndirectDefault from 'esdoc-test-fixture/src/Export/ClassIndirectDefault.js'`);
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ClassTest.js
@@ -6,33 +6,33 @@ import {readDoc, assert} from './../../util.js';
  */
 describe('test export class', ()=> {
   it('has default import path with direct class definition.', ()=> {
-    const doc = readDoc('class/src/Export/Class.js~TestExportClass1.html');
+    const doc = readDoc('class/src/Export/Class.js~TestExportClass1.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import TestExportClass1 from 'esdoc-test-fixture/src/Export/Class.js'`);
   });
 
   it('has named import path with direct.', ()=>{
-    const doc = readDoc('class/src/Export/Class.js~TestExportClass2.html');
+    const doc = readDoc('class/src/Export/Class.js~TestExportClass2.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import {TestExportClass2} from 'esdoc-test-fixture/src/Export/Class.js'`);
   });
 
   it('has named import path with indirect class definition', ()=>{
-    const doc = readDoc('class/src/Export/Class.js~TestExportClass3.html');
+    const doc = readDoc('class/src/Export/Class.js~TestExportClass3.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import {TestExportClass3} from 'esdoc-test-fixture/src/Export/Class.js'`);
   });
 
   it('has named import path with indirect class expression', ()=>{
-    const doc = readDoc('class/src/Export/Class.js~TestExportClass4.html');
+    const doc = readDoc('class/src/Export/Class.js~TestExportClass4.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import {TestExportClass4} from 'esdoc-test-fixture/src/Export/Class.js'`);
   });
 
   it('has named import path with undocument', ()=>{
-    const doc = readDoc('class/src/Export/Class.js~TestExportClass5.html');
+    const doc = readDoc('class/src/Export/Class.js~TestExportClass5.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import {TestExportClass5} from 'esdoc-test-fixture/src/Export/Class.js'`);
   });
 
   it('is not documented.', ()=> {
     try {
-      readDoc('class/src/Export/Class.js~TestExportClass6.html');
+      readDoc('class/src/Export/Class.js~TestExportClass6.html', 'Export');
     } catch (e) {
       return;
     }

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/DefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/DefaultTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert} from './../../util.js';
  * @test {ClassDocBuilder@_buildClassDoc}
  */
 describe('TestExportDefault', ()=> {
-  const doc = readDoc('class/src/Export/Default.js~TestExportDefault.html');
+  const doc = readDoc('class/src/Export/Default.js~TestExportDefault.html', 'Export');
   it('has default import path.', ()=> {
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import TestExportDefault from 'esdoc-test-fixture/src/Export/Default.js'`);
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ExtendTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/ExtendTest.js
@@ -3,6 +3,6 @@ import {readDoc} from './../../util.js';
 /** @test {DocResolver#_resolveNecessary} */
 describe('TestExportExtendsInner', ()=> {
   it('is documented.', ()=> {
-    readDoc('class/src/Export/Extends.js~TestExportExtendsInner.html');
+    readDoc('class/src/Export/Extends.js~TestExportExtendsInner.html', 'Export');
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionIndirectDefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionIndirectDefaultTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export function indirect default', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Export/function/index.html');
   it('has default import path with indirect function definition', ()=>{
     findParent(doc, '[id="static-function-testExportFunctionIndirectDefault"]', '[data-ice="detail"]', (doc)=>{
       assert.includes(doc, '[data-ice="importPath"]', `import testExportFunctionIndirectDefault from 'esdoc-test-fixture/src/Export/FunctionIndirectDefault.js'`);

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionIndirectDefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionIndirectDefaultTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export function indirect default', ()=> {
-  const doc = readDoc('Export/function/index.html');
+  const doc = readDoc('function/index.html', 'Export');
   it('has default import path with indirect function definition', ()=>{
     findParent(doc, '[id="static-function-testExportFunctionIndirectDefault"]', '[data-ice="detail"]', (doc)=>{
       assert.includes(doc, '[data-ice="importPath"]', `import testExportFunctionIndirectDefault from 'esdoc-test-fixture/src/Export/FunctionIndirectDefault.js'`);

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export function', ()=> {
-  const doc = readDoc('Export/function/index.html');
+  const doc = readDoc('function/index.html', 'Export');
 
   it('has default import path with direct function definition.', ()=> {
     findParent(doc, '[id="static-function-testExportFunction1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@_name} */
 describe('test export function', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Export/function/index.html');
 
   it('has default import path with direct function definition.', ()=> {
     findParent(doc, '[id="static-function-testExportFunction1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/MultipleTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/MultipleTest.js
@@ -3,10 +3,10 @@ import {readDoc, assert, findParent} from './../../util.js';
 /** @test {DocFactory#_inspectExportNamedDeclaration} */
 describe('test multiple export', ()=> {
   it('is documented.', ()=>{
-    const doc1 = readDoc('class/src/Export/Multiple.js~TestExportMultiple.html');
+    const doc1 = readDoc('class/src/Export/Multiple.js~TestExportMultiple.html', 'Export');
     assert.includes(doc1, '.header-notice [data-ice="importPath"]', `import {TestExportMultiple} from 'esdoc-test-fixture/src/Export/Multiple.js'`);
 
-    const doc2 = readDoc('Export/variable/index.html');
+    const doc2 = readDoc('variable/index.html', 'Export');
     findParent(doc2, '[id="static-variable-testExportMultiple"]', '[data-ice="detail"]', (doc)=>{
       assert.includes(doc, '[data-ice="importPath"]', `import {testExportMultiple} from 'esdoc-test-fixture/src/Export/Multiple.js'`);
     });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/MultipleTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/MultipleTest.js
@@ -6,7 +6,7 @@ describe('test multiple export', ()=> {
     const doc1 = readDoc('class/src/Export/Multiple.js~TestExportMultiple.html');
     assert.includes(doc1, '.header-notice [data-ice="importPath"]', `import {TestExportMultiple} from 'esdoc-test-fixture/src/Export/Multiple.js'`);
 
-    const doc2 = readDoc('variable/index.html');
+    const doc2 = readDoc('Export/variable/index.html');
     findParent(doc2, '[id="static-variable-testExportMultiple"]', '[data-ice="detail"]', (doc)=>{
       assert.includes(doc, '[data-ice="importPath"]', `import {testExportMultiple} from 'esdoc-test-fixture/src/Export/Multiple.js'`);
     });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NamedTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NamedTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert} from './../../util.js';
  */
 describe('TestExportNamed', ()=> {
   it('has named import path.', ()=>{
-    const doc = readDoc('class/src/Export/Named.js~TestExportNamed.html');
+    const doc = readDoc('class/src/Export/Named.js~TestExportNamed.html', 'Export');
     assert.includes(doc, '.header-notice [data-ice="importPath"]', `import {TestExportNamed} from 'esdoc-test-fixture/src/Export/Named.js'`);
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionIndirectTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionIndirectTest.js
@@ -24,7 +24,7 @@ describe('test default export with new expression and indirect.', ()=> {
   });
 
   it('has class description', ()=>{
-    const doc = readDoc('variable/index.html');
+    const doc = readDoc('Export/variable/index.html');
 
     findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpressionIndirect"]', '[data-ice="target"]', (doc)=>{
       assert.includes(doc, null, 'public testExportNewExpressionIndirect: TestExportNewExpressionIndirect');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionIndirectTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionIndirectTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
  */
 describe('test default export with new expression and indirect.', ()=> {
   it('has instance description', ()=> {
-    const doc = readDoc('class/src/Export/NewExpressionIndirect.js~TestExportNewExpressionIndirect.html');
+    const doc = readDoc('class/src/Export/NewExpressionIndirect.js~TestExportNewExpressionIndirect.html', 'Export');
 
     find(doc, '[data-ice="instanceDocs"]', (doc)=>{
       assert.includes(doc, null, 'You can directly use an instance of this class. testExportNewExpressionIndirect');
@@ -24,7 +24,7 @@ describe('test default export with new expression and indirect.', ()=> {
   });
 
   it('has class description', ()=>{
-    const doc = readDoc('Export/variable/index.html');
+    const doc = readDoc('variable/index.html', 'Export');
 
     findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpressionIndirect"]', '[data-ice="target"]', (doc)=>{
       assert.includes(doc, null, 'public testExportNewExpressionIndirect: TestExportNewExpressionIndirect');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionPropertyTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionPropertyTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
  */
 describe('test default export with new expression and property.', ()=> {
   it('has instance description', ()=> {
-    const doc = readDoc('class/src/Export/NewExpressionProperty.js~TestExportNewExpressionProperty.html');
+    const doc = readDoc('class/src/Export/NewExpressionProperty.js~TestExportNewExpressionProperty.html', 'Export');
 
     find(doc, '[data-ice="instanceDocs"]', (doc)=>{
       assert.includes(doc, null, 'You can directly use an instance of this class. testExportNewExpressionProperty');
@@ -24,7 +24,7 @@ describe('test default export with new expression and property.', ()=> {
   });
 
   it('has class description', ()=>{
-    const doc = readDoc('Export/variable/index.html');
+    const doc = readDoc('variable/index.html', 'Export');
 
     findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpressionProperty"]', '[data-ice="target"]', (doc)=>{
       assert.includes(doc, null, 'public testExportNewExpressionProperty: TestExportNewExpressionProperty');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionPropertyTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionPropertyTest.js
@@ -24,7 +24,7 @@ describe('test default export with new expression and property.', ()=> {
   });
 
   it('has class description', ()=>{
-    const doc = readDoc('variable/index.html');
+    const doc = readDoc('Export/variable/index.html');
 
     findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpressionProperty"]', '[data-ice="target"]', (doc)=>{
       assert.includes(doc, null, 'public testExportNewExpressionProperty: TestExportNewExpressionProperty');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionTest.js
@@ -7,7 +7,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
 describe('test default export with new expression.', ()=> {
   describe('default export', ()=>{
     it('has instance description', ()=> {
-      const doc = readDoc('class/src/Export/NewExpression.js~TestExportNewExpression.html');
+      const doc = readDoc('class/src/Export/NewExpression.js~TestExportNewExpression.html', 'Export');
 
       find(doc, '[data-ice="instanceDocs"]', (doc)=>{
         assert.includes(doc, null, 'You can directly use an instance of this class. testExportNewExpression');
@@ -25,7 +25,7 @@ describe('test default export with new expression.', ()=> {
     });
 
     it('has class description', ()=>{
-      const doc = readDoc('Export/variable/index.html');
+      const doc = readDoc('variable/index.html', 'Export');
 
       findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpression"]', '[data-ice="target"]', (doc)=>{
         assert.includes(doc, null, 'public testExportNewExpression: TestExportNewExpression');
@@ -40,7 +40,7 @@ describe('test default export with new expression.', ()=> {
 
   describe('named export', ()=>{
     it('has instance description', ()=> {
-      const doc = readDoc('class/src/Export/NewExpression.js~TestExportNewExpression2.html');
+      const doc = readDoc('class/src/Export/NewExpression.js~TestExportNewExpression2.html', 'Export');
 
       find(doc, '[data-ice="instanceDocs"]', (doc)=>{
         assert.includes(doc, null, 'You can directly use an instance of this class. testExportNewExpression2');
@@ -58,7 +58,7 @@ describe('test default export with new expression.', ()=> {
     });
 
     it('has class description', ()=>{
-      const doc = readDoc('Export/variable/index.html');
+      const doc = readDoc('variable/index.html', 'Export');
 
       findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpression2"]', '[data-ice="target"]', (doc)=>{
         assert.includes(doc, null, 'public testExportNewExpression2: TestExportNewExpression2');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/NewExpressionTest.js
@@ -25,7 +25,7 @@ describe('test default export with new expression.', ()=> {
     });
 
     it('has class description', ()=>{
-      const doc = readDoc('variable/index.html');
+      const doc = readDoc('Export/variable/index.html');
 
       findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpression"]', '[data-ice="target"]', (doc)=>{
         assert.includes(doc, null, 'public testExportNewExpression: TestExportNewExpression');
@@ -58,7 +58,7 @@ describe('test default export with new expression.', ()=> {
     });
 
     it('has class description', ()=>{
-      const doc = readDoc('variable/index.html');
+      const doc = readDoc('Export/variable/index.html');
 
       findParent(doc, '[data-ice="summary"] [href$="#static-variable-testExportNewExpression2"]', '[data-ice="target"]', (doc)=>{
         assert.includes(doc, null, 'public testExportNewExpression2: TestExportNewExpression2');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableIndirectDefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableIndirectDefaultTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc#@_name} */
 describe('test export variable indirect default', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Export/variable/index.html');
 
   it('has default import path with indirect variable definition.', ()=> {
     findParent(doc, '[id="static-variable-testExportVariableIndirectDefault"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableIndirectDefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableIndirectDefaultTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc#@_name} */
 describe('test export variable indirect default', ()=> {
-  const doc = readDoc('Export/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Export');
 
   it('has default import path with indirect variable definition.', ()=> {
     findParent(doc, '[id="static-variable-testExportVariableIndirectDefault"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc#@_name} */
 describe('test export variable', ()=> {
-  const doc = readDoc('Export/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Export');
 
   it('has default import path with direct variable definition.', ()=> {
     findParent(doc, '[id="static-variable-testExportVariable1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExportTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc#@_name} */
 describe('test export variable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Export/variable/index.html');
 
   it('has default import path with direct variable definition.', ()=> {
     findParent(doc, '[id="static-variable-testExportVariable1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/BuiltinTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/BuiltinTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDoc#@extends} */
 describe('TestExtendsBuiltin', ()=> {
-  const doc = readDoc('class/src/Extends/Builtin.js~TestExtendsBuiltin.html');
+  const doc = readDoc('class/src/Extends/Builtin.js~TestExtendsBuiltin.html', 'Extends');
 
   it('has extends chain.', ()=> {
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/DeepTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/DeepTest.js
@@ -6,14 +6,14 @@ import {readDoc, assert, find, findParent} from './../../util.js';
  */
 describe('test deep extends', ()=>{
   describe('TestExtendsDeepSquare', ()=> {
-    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepSquare.html');
+    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepSquare.html', 'Extends');
 
     it('has extends chain.', ()=> {
       find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{
         assert.includes(doc, null, 'TestExtendsDeepShape → TestExtendsDeepRectangle → TestExtendsDeepSquare');
         assert.includes(doc, 'a[href$="Array"]', 'Array');
-        assert.includes(doc, 'a[href="class/src/Extends/Deep.js~TestExtendsDeepShape.html"]', 'TestExtendsDeepShape');
-        assert.includes(doc, 'a[href="class/src/Extends/Deep.js~TestExtendsDeepRectangle.html"]', 'TestExtendsDeepRectangle');
+        assert.includes(doc, 'a[href$="class/src/Extends/Deep.js~TestExtendsDeepShape.html"]', 'TestExtendsDeepShape');
+        assert.includes(doc, 'a[href$="class/src/Extends/Deep.js~TestExtendsDeepRectangle.html"]', 'TestExtendsDeepRectangle');
       });
     });
 
@@ -53,27 +53,27 @@ describe('test deep extends', ()=>{
   });
 
   describe('TestExtendsDeepRectangle', ()=>{
-    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepRectangle.html');
+    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepRectangle.html', 'Extends');
 
     it('has direct subclass.', ()=> {
       find(doc, '.self-detail [data-ice="directSubclass"]', (doc)=>{
-        assert.includes(doc, 'a[href="class/src/Extends/Deep.js~TestExtendsDeepSquare.html"]', 'TestExtendsDeepSquare');
+        assert.includes(doc, 'a[href$="class/src/Extends/Deep.js~TestExtendsDeepSquare.html"]', 'TestExtendsDeepSquare');
       });
     });
   });
 
   describe('TestExtendsDeepShape', ()=>{
-    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepShape.html');
+    const doc = readDoc('class/src/Extends/Deep.js~TestExtendsDeepShape.html', 'Extends');
 
     it('has direct subclass.', ()=> {
       find(doc, '.self-detail [data-ice="directSubclass"]', (doc)=>{
-        assert.includes(doc, 'a[href="class/src/Extends/Deep.js~TestExtendsDeepRectangle.html"]', 'TestExtendsDeepRectangle');
+        assert.includes(doc, 'a[href$="class/src/Extends/Deep.js~TestExtendsDeepRectangle.html"]', 'TestExtendsDeepRectangle');
       });
     });
 
     it('has indirect subclass.', ()=> {
       find(doc, '.self-detail [data-ice="indirectSubclass"]', (doc)=>{
-        assert.includes(doc, 'a[href="class/src/Extends/Deep.js~TestExtendsDeepSquare.html"]', 'TestExtendsDeepSquare');
+        assert.includes(doc, 'a[href$="class/src/Extends/Deep.js~TestExtendsDeepSquare.html"]', 'TestExtendsDeepSquare');
       });
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/ExpressionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/ExpressionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDoc#@extends} */
 describe('TestExtendsExpression', ()=> {
-  const doc = readDoc('class/src/Extends/Expression.js~TestExtendsExpression.html');
+  const doc = readDoc('class/src/Extends/Expression.js~TestExtendsExpression.html', 'Extends');
 
   it('has expression extends.', ()=> {
     find(doc, '.self-detail [data-ice="expressionExtends"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/InnerTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/InnerTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert, find} from './../../util.js';
  */
 describe('TestExtendsInner', ()=> {
   it('has extends chain.', ()=>{
-    const doc = readDoc('class/src/Extends/Inner.js~TestExtendsInner.html');
+    const doc = readDoc('class/src/Extends/Inner.js~TestExtendsInner.html', 'Extends');
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{
       assert.includes(doc, null, '_TestExtendsInner → TestExtendsInner');
       assert.includes(doc, 'a[href$="_TestExtendsInner.html"]', '_TestExtendsInner');
@@ -14,9 +14,9 @@ describe('TestExtendsInner', ()=> {
   });
 
   it('has direct subclass.', ()=>{
-    const doc = readDoc('class/src/Extends/Inner.js~_TestExtendsInner.html');
+    const doc = readDoc('class/src/Extends/Inner.js~_TestExtendsInner.html', 'Extends');
     find(doc, '.self-detail [data-ice="directSubclass"]', (doc)=>{
-      assert.includes(doc, 'a[href="class/src/Extends/Inner.js~TestExtendsInner.html"]', 'TestExtendsInner');
+      assert.includes(doc, 'a[href$="class/src/Extends/Inner.js~TestExtendsInner.html"]', 'TestExtendsInner');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/MixinTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/MixinTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, find} from './../../util.js';
  * @test {DocResolver#_resolveNecessary}
  */
 describe('TestExtendsMixin', ()=> {
-  const doc = readDoc('class/src/Extends/Mixin.js~TestExtendsMixin.html');
+  const doc = readDoc('class/src/Extends/Mixin.js~TestExtendsMixin.html', 'Extends');
 
   it('has expression extends.', ()=> {
     find(doc, '.self-detail [data-ice="expressionExtends"]', (doc)=>{
@@ -16,8 +16,8 @@ describe('TestExtendsMixin', ()=> {
   it('has extends chain.', ()=> {
     find(doc, '.self-detail [data-ice="mixinExtends"]', (doc)=>{
       assert.includes(doc, null, 'TestExtendsMixinInner1, TestExtendsMixinInner2');
-      assert.includes(doc, 'a[href="class/src/Extends/Mixin.js~TestExtendsMixinInner1.html"]', 'TestExtendsMixinInner1');
-      assert.includes(doc, 'a[href="class/src/Extends/Mixin.js~TestExtendsMixinInner2.html"]', 'TestExtendsMixinInner2');
+      assert.includes(doc, 'a[href$="class/src/Extends/Mixin.js~TestExtendsMixinInner1.html"]', 'TestExtendsMixinInner1');
+      assert.includes(doc, 'a[href$="class/src/Extends/Mixin.js~TestExtendsMixinInner2.html"]', 'TestExtendsMixinInner2');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/OuterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/OuterTest.js
@@ -2,13 +2,13 @@ import {readDoc, assert, find, findParent} from './../../util.js';
 
 /** @test {ClassDoc#@extends} */
 describe('TestExtendsOuter', ()=> {
-  const doc = readDoc('class/src/Extends/Outer.js~TestExtendsOuter.html');
+  const doc = readDoc('class/src/Extends/Outer.js~TestExtendsOuter.html', 'Extends');
 
   it('has extends chain.', ()=> {
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{
       assert.includes(doc, null, 'Array → TestExtendsBuiltin → TestExtendsOuter');
       assert.includes(doc, 'a[href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"]', 'Array');
-      assert.includes(doc, 'a[href="class/src/Extends/Builtin.js~TestExtendsBuiltin.html"]', 'TestExtendsBuiltin');
+      assert.includes(doc, 'a[href$="class/src/Extends/Builtin.js~TestExtendsBuiltin.html"]', 'TestExtendsBuiltin');
     });
   });
 

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/PropertyTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/PropertyTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDoc#@extends} */
 describe('TestExtendsProperty', ()=> {
-  const doc = readDoc('class/src/Extends/Property.js~TestExtendsProperty.html');
+  const doc = readDoc('class/src/Extends/Property.js~TestExtendsProperty.html', 'Extends');
 
   it('has extends chain.', ()=> {
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@_generator} */
 describe('testGeneratorFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Generator/function/index.html');
 
   describe('in summary', ()=> {
     it('has generator mark', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@_generator} */
 describe('testGeneratorFunction', ()=> {
-  const doc = readDoc('Generator/function/index.html');
+  const doc = readDoc('function/index.html', 'Generator');
 
   describe('in summary', ()=> {
     it('has generator mark', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/GeneratorTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@_generator} */
 describe('TestGeneratorMethod', ()=> {
-  const doc = readDoc('class/src/Generator/Method.js~TestGeneratorMethod.html');
+  const doc = readDoc('class/src/Generator/Method.js~TestGeneratorMethod.html', 'Generator');
 
   describe('in summary', ()=> {
     it('has generator mark.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/ClassTest.js
@@ -4,12 +4,12 @@ import {readDoc, assert, find} from './../../util.js';
 describe('test ignore class', ()=>{
   describe('TestIgnoreClass1', ()=> {
     it('is not documented.', ()=> {
-      assert.throws(()=> readDoc('class/src/Ignore/Class.js~TestIgnoreClass1.html'));
+      assert.throws(()=> readDoc('class/src/Ignore/Class.js~TestIgnoreClass1.html', 'Ignore'));
     });
   });
 
   describe('TestIgnoreClass2', ()=>{
-    const doc = readDoc('class/src/Ignore/Class.js~TestIgnoreClass2.html');
+    const doc = readDoc('class/src/Ignore/Class.js~TestIgnoreClass2.html', 'Ignore');
 
     it('does not have ignored member.', ()=>{
       assert.throws(()=> find(doc, '[data-ice="summary"] [href$="#instance-member-p1"]', ()=>{}));

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/FunctionTest.js
@@ -2,10 +2,8 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {DocResolver#_resolveIgnore */
 describe('testIgnoreFunction', ()=>{
-  const doc = readDoc('function/index.html');
 
   it('is not documented.', ()=>{
-    assert.throws(()=> find(doc, '[data-ice="summary"] [href$="#static-function-testIgnoreFunction"]', ()=>{}));
-    assert.throws(()=> find(doc, '[id="static-function-testIgnoreFunction"]', ()=>{}));
+    assert.throws(()=> readDoc('Ignore/function/index.html'));
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/FunctionTest.js
@@ -1,9 +1,15 @@
-import {readDoc, assert, find} from './../../util.js';
+import {readDoc, assert, find, pluginOptions} from './../../util.js';
 
 /** @test {DocResolver#_resolveIgnore */
 describe('testIgnoreFunction', ()=>{
 
   it('is not documented.', ()=>{
-    assert.throws(()=> readDoc('Ignore/function/index.html'));
+    if (pluginOptions.organizePaths) {
+      assert.throws(()=> readDoc('function/index.html', 'Ignore'));
+    } else {
+      const doc = readDoc('function/index.html');
+      assert.throws(()=> find(doc, '[data-ice="summary"] [href$="#static-function-testIgnoreFunction"]', ()=>{}));
+      assert.throws(()=> find(doc, '[id="static-function-testIgnoreFunction"]', ()=>{}));
+    }
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/VariableTest.js
@@ -2,10 +2,8 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {DocResolver#_resolveIgnore */
 describe('testIgnoreVariable', ()=>{
-  const doc = readDoc('variable/index.html');
 
   it('is not documented.', ()=>{
-    assert.throws(()=> find(doc, '[data-ice="summary"] [href$="#static-variable-testIgnoreVariable"]', ()=>{}));
-    assert.throws(()=> find(doc, '[id="static-variable-testIgnoreVariable"]', ()=>{}));
+    assert.throws(()=> readDoc('Ignore/variable/index.html'));
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/IgnoreTest/VariableTest.js
@@ -1,9 +1,15 @@
-import {readDoc, assert, find} from './../../util.js';
+import {readDoc, assert, find, pluginOptions} from './../../util.js';
 
 /** @test {DocResolver#_resolveIgnore */
 describe('testIgnoreVariable', ()=>{
 
   it('is not documented.', ()=>{
-    assert.throws(()=> readDoc('Ignore/variable/index.html'));
+    if (pluginOptions.organizePaths) {
+      assert.throws(()=> readDoc('variable/index.html', 'Ignore'));
+    } else {
+      const doc = readDoc('variable/index.html');
+      assert.throws(()=> find(doc, '[data-ice="summary"] [href$="#static-variable-testIgnoreVariable"]', ()=>{}));
+      assert.throws(()=> find(doc, '[id="static-variable-testIgnoreVariable"]', ()=>{}));
+    }
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/InterfaceTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/InterfaceTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDoc#@interface} */
 describe('TestInterfaceDefinition', ()=> {
-  const doc = readDoc('class/src/Interface/Definition.js~TestInterfaceDefinition.html');
+  const doc = readDoc('class/src/Interface/Definition.js~TestInterfaceDefinition.html', 'Interface');
 
   it('has interface mark.', ()=> {
     assert.includes(doc, '.header-notice [data-ice="kind"]', 'interface');
@@ -10,7 +10,7 @@ describe('TestInterfaceDefinition', ()=> {
 
   it('has direct subclass.', ()=>{
     find(doc, '.self-detail [data-ice="directImplemented"]', (doc)=>{
-      assert.includes(doc, 'a[href="class/src/Interface/Implements.js~TestInterfaceImplements.html"]', 'TestInterfaceImplements');
+      assert.includes(doc, 'a[href$="class/src/Interface/Implements.js~TestInterfaceImplements.html"]', 'TestInterfaceImplements');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/InterfaceTest/ImplementsTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/InterfaceTest/ImplementsTest.js
@@ -2,13 +2,13 @@ import {readDoc, assert, find} from './../../util.js';
 
 /** @test {ClassDoc#@implements} */
 describe('TestInterfaceImplements', ()=> {
-  const doc = readDoc('class/src/Interface/Implements.js~TestInterfaceImplements.html');
+  const doc = readDoc('class/src/Interface/Implements.js~TestInterfaceImplements.html', 'Interface');
 
   it('has implements.', ()=>{
     find(doc, '.self-detail [data-ice="implements"]', (doc)=>{
       assert.includes(doc, 'ul', 'TestInterfaceDefinition, TestInterfaceImplementsInner');
-      assert.includes(doc, 'ul a[href="class/src/Interface/Definition.js~TestInterfaceDefinition.html"]', 'TestInterfaceDefinition');
-      assert.includes(doc, 'ul a[href="class/src/Interface/Implements.js~TestInterfaceImplementsInner.html"]', 'TestInterfaceImplementsInner');
+      assert.includes(doc, 'ul a[href$="class/src/Interface/Definition.js~TestInterfaceDefinition.html"]', 'TestInterfaceDefinition');
+      assert.includes(doc, 'ul a[href$="class/src/Interface/Implements.js~TestInterfaceImplementsInner.html"]', 'TestInterfaceImplementsInner');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/ClassTest.js
@@ -2,27 +2,27 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveLink} */
 describe('TestLinkClass', ()=> {
-  const doc = readDoc('class/src/Link/Class.js~TestLinkClass.html');
+  const doc = readDoc('class/src/Link/Class.js~TestLinkClass.html', 'Link');
 
   it('has link from class.', ()=> {
-    assert.includes(doc, '.self-detail [data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+    assert.includes(doc, '.self-detail [data-ice="description"] a[href$="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
   });
 
   it('has link from constructor.', ()=>{
     findParent(doc, '[id="instance-constructor-constructor"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href$="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 
   it('has link from member.', ()=>{
     findParent(doc, '[id="instance-member-p1"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href$="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 
   it('has link from method.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href$="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/ClassTest.js
@@ -5,24 +5,24 @@ describe('TestLinkClass', ()=> {
   const doc = readDoc('class/src/Link/Class.js~TestLinkClass.html');
 
   it('has link from class.', ()=> {
-    assert.includes(doc, '.self-detail [data-ice="description"] a[href="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+    assert.includes(doc, '.self-detail [data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
   });
 
   it('has link from constructor.', ()=>{
     findParent(doc, '[id="instance-constructor-constructor"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 
   it('has link from member.', ()=>{
     findParent(doc, '[id="instance-member-p1"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 
   it('has link from method.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="description"] a[href="function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
+      assert.includes(doc, '[data-ice="description"] a[href="Link/function/index.html#static-function-testLinkFunction"]', 'testLinkFunction');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveLink} */
 describe('testLinkFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Link/function/index.html');
 
   it('has link.', ()=>{
     findParent(doc, '[id="static-function-testLinkFunction"]', '[data-ice="detail"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/FunctionTest.js
@@ -2,13 +2,13 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveLink} */
 describe('testLinkFunction', ()=> {
-  const doc = readDoc('Link/function/index.html');
+  const doc = readDoc('function/index.html', 'Link');
 
   it('has link.', ()=>{
     findParent(doc, '[id="static-function-testLinkFunction"]', '[data-ice="detail"]', (doc)=> {
-      assert.includes(doc, '[data-ice="description"] a[href="class/src/Link/Class.js~TestLinkClass.html"]', 'TestLinkClass');
-      assert.includes(doc, '[data-ice="description"] a[href="class/src/Link/Class.js~TestLinkClass.html#instance-member-p1"]', 'TestLinkClass#p1');
-      assert.includes(doc, '[data-ice="description"] a[href="class/src/Link/Class.js~TestLinkClass.html#instance-method-method1"]', 'TestLinkClass#method1');
+      assert.includes(doc, '[data-ice="description"] a[href$="class/src/Link/Class.js~TestLinkClass.html"]', 'TestLinkClass');
+      assert.includes(doc, '[data-ice="description"] a[href$="class/src/Link/Class.js~TestLinkClass.html#instance-member-p1"]', 'TestLinkClass#p1');
+      assert.includes(doc, '[data-ice="description"] a[href$="class/src/Link/Class.js~TestLinkClass.html#instance-method-method1"]', 'TestLinkClass#method1');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/VariableTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveLink} */
 describe('testLinkVariable', ()=> {
-  const doc = readDoc('Link/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Link');
 
   it('has link.', ()=>{
     findParent(doc, '[id="static-variable-testLinkVariable"]', '[data-ice="detail"]', (doc)=> {
-      assert.includes(doc, '[data-ice="description"] a[href="class/src/Link/Class.js~TestLinkClass.html"]', 'TestLinkClass');
+      assert.includes(doc, '[data-ice="description"] a[href$="class/src/Link/Class.js~TestLinkClass.html"]', 'TestLinkClass');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/LinkTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {DocResolver#_resolveLink} */
 describe('testLinkVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Link/variable/index.html');
 
   it('has link.', ()=>{
     findParent(doc, '[id="static-variable-testLinkVariable"]', '[data-ice="detail"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/FunctionTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@listens} */
 describe('testListensFunction', ()=> {
-  const doc = readDoc('Listens/function/index.html');
+  const doc = readDoc('function/index.html', 'Listens');
 
   it('has listens.', ()=>{
     findParent(doc, '[id="static-function-testListensFunction"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="listen"] a[href="class/src/Listens/Function.js~TestListensFunctionEvent.html"]', 'TestListensFunctionEvent');
+      assert.includes(doc, '[data-ice="listen"] a[href$="class/src/Listens/Function.js~TestListensFunctionEvent.html"]', 'TestListensFunctionEvent');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@listens} */
 describe('testListensFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Listens/function/index.html');
 
   it('has listens.', ()=>{
     findParent(doc, '[id="static-function-testListensFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ListensTest/MethodTest.js
@@ -2,18 +2,18 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@listens} */
 describe('TestListensMethod', ()=> {
-  const doc = readDoc('class/src/Listens/Method.js~TestListensMethod.html');
+  const doc = readDoc('class/src/Listens/Method.js~TestListensMethod.html', 'Listens');
 
   it('has listens.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{
-      findParent(doc, 'a[href="class/src/Listens/Method.js~TestListensMethodEvent1.html"]', '[data-ice="listen"]', (doc)=>{
+      findParent(doc, 'a[href$="class/src/Listens/Method.js~TestListensMethodEvent1.html"]', '[data-ice="listen"]', (doc)=>{
         assert.includes(doc, null, 'TestListensMethodEvent1 listen event because foo.');
-        assert.includes(doc, 'a[href="class/src/Listens/Method.js~TestListensMethodEvent1.html"]', 'TestListensMethodEvent1');
+        assert.includes(doc, 'a[href$="class/src/Listens/Method.js~TestListensMethodEvent1.html"]', 'TestListensMethodEvent1');
       });
 
-      findParent(doc, 'a[href="class/src/Listens/Method.js~TestListensMethodEvent2.html"]', '[data-ice="listen"]', (doc)=>{
+      findParent(doc, 'a[href$="class/src/Listens/Method.js~TestListensMethodEvent2.html"]', '[data-ice="listen"]', (doc)=>{
         assert.includes(doc, null, 'TestListensMethodEvent2 listen event because bar.');
-        assert.includes(doc, 'a[href="class/src/Listens/Method.js~TestListensMethodEvent2.html"]', 'TestListensMethodEvent2');
+        assert.includes(doc, 'a[href$="class/src/Listens/Method.js~TestListensMethodEvent2.html"]', 'TestListensMethodEvent2');
       });
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@param} */
 describe('testParamFunction', ()=> {
-  const doc = readDoc('Param/function/index.html');
+  const doc = readDoc('function/index.html', 'Param');
 
   describe('in summary', ()=> {
     it('has param.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@param} */
 describe('testParamFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Param/function/index.html');
 
   describe('in summary', ()=> {
     it('has param.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ParamTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@desc} */
 describe('TestParamMethod', ()=> {
-  const doc = readDoc('class/src/Param/Method.js~TestParamMethod.html');
+  const doc = readDoc('class/src/Param/Method.js~TestParamMethod.html', 'Param');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/PropertyTest/ReturnTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/PropertyTest/ReturnTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@property} */
 describe('TestPropertyReturn', ()=> {
-  const doc = readDoc('class/src/Property/Return.js~TestPropertyReturn.html');
+  const doc = readDoc('class/src/Property/Return.js~TestPropertyReturn.html', 'Property');
 
   describe('in details', ()=>{
     it('has desc.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@return} */
 describe('test return', ()=>{
-  const doc = readDoc('Return/function/index.html');
+  const doc = readDoc('function/index.html', 'Return');
 
   describe('testReturnFunction1', ()=> {
     describe('in summary', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {FunctionDoc#@return} */
 describe('test return', ()=>{
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Return/function/index.html');
 
   describe('testReturnFunction1', ()=> {
     describe('in summary', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ReturnTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {MethodDoc#@return} */
 describe('TestReturnMethod', ()=> {
-  const doc = readDoc('class/src/Return/Method.js~TestReturnMethod.html');
+  const doc = readDoc('class/src/Return/Method.js~TestReturnMethod.html', 'Return');
 
   describe('in summary', ()=> {
     it('has return', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@see} */
 describe('TestSeeClass', ()=> {
-  const doc = readDoc('class/src/See/Class.js~TestSeeClass.html');
+  const doc = readDoc('class/src/See/Class.js~TestSeeClass.html', 'See');
 
   it('has see from class.', ()=> {
     find(doc, '.self-detail [data-ice="see"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@see} */
 describe('testSeeFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('See/function/index.html');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-function-testSeeFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@see} */
 describe('testSeeFunction', ()=> {
-  const doc = readDoc('See/function/index.html');
+  const doc = readDoc('function/index.html', 'See');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-function-testSeeFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@see} */
 describe('testSeeVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('See/variable/index.html');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-variable-testSeeVariable"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SeeTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@see} */
 describe('testSeeVariable', ()=> {
-  const doc = readDoc('See/variable/index.html');
+  const doc = readDoc('variable/index.html', 'See');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-variable-testSeeVariable"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@since} */
 describe('TestSinceClass', ()=> {
-  const doc = readDoc('class/src/Since/Class.js~TestSinceClass.html');
+  const doc = readDoc('class/src/Since/Class.js~TestSinceClass.html', 'Since');
 
   it('has since at class.', ()=> {
     assert.includes(doc, '.header-notice [data-ice="since"]', 'since 1.2.3');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@since} */
 describe('testSinceFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Since/function/index.html');
 
   describe('in summary', ()=>{
     it('has since.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@since} */
 describe('testSinceFunction', ()=> {
-  const doc = readDoc('Since/function/index.html');
+  const doc = readDoc('function/index.html', 'Since');
 
   describe('in summary', ()=>{
     it('has since.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@since} */
 describe('testSinceVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Since/variable/index.html');
 
   describe('in summary', ()=>{
     it('has since.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/SinceTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@since} */
 describe('testSinceVariable', ()=> {
-  const doc = readDoc('Since/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Since');
 
   describe('in summary', ()=>{
     it('has since.', ()=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/FunctionTest.js
@@ -2,11 +2,11 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@throws} */
 describe('testThrowsFunction', ()=> {
-  const doc = readDoc('Throws/function/index.html');
+  const doc = readDoc('function/index.html', 'Throws');
 
   it('has throws.', ()=>{
     findParent(doc, '[id="static-function-testThrowsFunction"]', '[data-ice="detail"]', (doc)=>{
-      assert.includes(doc, '[data-ice="throw"] a[href="class/src/Throws/Function.js~TestThrowsFunctionError.html"]', 'TestThrowsFunctionError');
+      assert.includes(doc, '[data-ice="throw"] a[href$="class/src/Throws/Function.js~TestThrowsFunctionError.html"]', 'TestThrowsFunctionError');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@throws} */
 describe('testThrowsFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Throws/function/index.html');
 
   it('has throws.', ()=>{
     findParent(doc, '[id="static-function-testThrowsFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/MethodTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ThrowsTest/MethodTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@throws} */
 describe('TestThrowsMethod', ()=> {
-  const doc = readDoc('class/src/Throws/Method.js~TestThrowsMethod.html');
+  const doc = readDoc('class/src/Throws/Method.js~TestThrowsMethod.html', 'Throws');
 
   it('has throws.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, find, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@todo} */
 describe('TestTodoClass', ()=> {
-  const doc = readDoc('class/src/Todo/Class.js~TestTodoClass.html');
+  const doc = readDoc('class/src/Todo/Class.js~TestTodoClass.html', 'Todo');
 
   it('has todo at class.', ()=> {
     find(doc, '.self-detail [data-ice="todo"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@todo} */
 describe('testTodoFunction', ()=> {
-  const doc = readDoc('Todo/function/index.html');
+  const doc = readDoc('function/index.html', 'Todo');
 
   it('has todo.', ()=>{
     findParent(doc, '[id="static-function-testTodoFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@todo} */
 describe('testTodoFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Todo/function/index.html');
 
   it('has todo.', ()=>{
     findParent(doc, '[id="static-function-testTodoFunction"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@todo} */
 describe('testTodoVariable', ()=> {
-  const doc = readDoc('Todo/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Todo');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-variable-testTodoVariable"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TodoTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@todo} */
 describe('testTodoVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Todo/variable/index.html');
 
   it('has see.', ()=>{
     findParent(doc, '[id="static-variable-testTodoVariable"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TrailingCommaTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TrailingCommaTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {ESParser} */
 describe('TestTrailingCommaDefinition', ()=> {
-  const doc = readDoc('class/src/TrailingComma/Definition.js~TestTrailingCommaDefinition.html');
+  const doc = readDoc('class/src/TrailingComma/Definition.js~TestTrailingCommaDefinition.html', 'TrailingComma');
 
   describe('in self detail', ()=> {
     it('has desc.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ArrayTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ArrayTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeArray', ()=> {
-  const doc = readDoc('class/src/Type/Array.js~TestTypeArray.html');
+  const doc = readDoc('class/src/Type/Array.js~TestTypeArray.html', 'Type');
 
   it('has array type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ClassTest.js
@@ -5,12 +5,12 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeClass', ()=> {
-  const doc = readDoc('class/src/Type/Class.js~TestTypeClass.html');
+  const doc = readDoc('class/src/Type/Class.js~TestTypeClass.html', 'Type');
 
   it('has class type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: TestTypeClassInner)');
-      assert.includes(doc, 'a[href="class/src/Type/Class.js~TestTypeClassInner.html"]', 'TestTypeClassInner');
+      assert.includes(doc, 'a[href$="class/src/Type/Class.js~TestTypeClassInner.html"]', 'TestTypeClassInner');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ComplexTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ComplexTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeComplex', ()=> {
-  const doc = readDoc('class/src/Type/Complex.js~TestTypeComplex.html');
+  const doc = readDoc('class/src/Type/Complex.js~TestTypeComplex.html', 'Type');
 
   it('has function complex type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/DefaultTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/DefaultTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeDefault', ()=> {
-  const doc = readDoc('class/src/Type/Default.js~TestTypeDefault.html');
+  const doc = readDoc('class/src/Type/Default.js~TestTypeDefault.html', 'Type');
 
   it('has default value.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ExternalTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ExternalTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeExternal', ()=> {
-  const doc = readDoc('class/src/Type/External.js~TestTypeExternal.html');
+  const doc = readDoc('class/src/Type/External.js~TestTypeExternal.html', 'Type');
 
   it('has external type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/FunctionTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeFunction', ()=> {
-  const doc = readDoc('class/src/Type/Function.js~TestTypeFunction.html');
+  const doc = readDoc('class/src/Type/Function.js~TestTypeFunction.html', 'Type');
 
   it('has function type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/GenericsTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/GenericsTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeGenerics', ()=> {
-  const doc = readDoc('class/src/Type/Generics.js~TestTypeGenerics.html');
+  const doc = readDoc('class/src/Type/Generics.js~TestTypeGenerics.html', 'Type');
 
   it('has generics type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/LiteralTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/LiteralTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeLiteral', ()=> {
-  const doc = readDoc('class/src/Type/Literal.js~TestTypeLiteral.html');
+  const doc = readDoc('class/src/Type/Literal.js~TestTypeLiteral.html', 'Type');
 
   it('has literal type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/NullableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/NullableTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeNullable', ()=> {
-  const doc = readDoc('class/src/Type/Nullable.js~TypeTestNullable.html');
+  const doc = readDoc('class/src/Type/Nullable.js~TypeTestNullable.html', 'Type');
 
   it('has nullable value.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ObjectTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ObjectTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeObject', ()=> {
-  const doc = readDoc('class/src/Type/Object.js~TestTypeObject.html');
+  const doc = readDoc('class/src/Type/Object.js~TestTypeObject.html', 'Type');
 
   it('has object type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/OptionalTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/OptionalTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeOptional', ()=> {
-  const doc = readDoc('class/src/Type/Optional.js~TestTypeOptional.html');
+  const doc = readDoc('class/src/Type/Optional.js~TestTypeOptional.html', 'Type');
 
   it('has optional attribute.', ()=>{
     findParent(doc, '[id="instance-method-method1"]', '[data-ice="detail"]', (doc)=>{

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/RecordTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/RecordTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeRecord', ()=> {
-  const doc = readDoc('class/src/Type/Record.js~TestTypeRecord.html');
+  const doc = readDoc('class/src/Type/Record.js~TestTypeRecord.html', 'Type');
 
   it('has record type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/SpreadTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/SpreadTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeSpread', ()=> {
-  const doc = readDoc('class/src/Type/Spread.js~TestTypeSpread.html');
+  const doc = readDoc('class/src/Type/Spread.js~TestTypeSpread.html', 'Type');
 
   it('has spread type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/TypedefTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/TypedefTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeTypedef', ()=> {
-  const doc = readDoc('class/src/Type/Typedef.js~TestTypeTypedef.html');
+  const doc = readDoc('class/src/Type/Typedef.js~TestTypeTypedef.html', 'Type');
 
   it('has typedef type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/UnionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/UnionTest.js
@@ -5,7 +5,7 @@ import {readDoc, assert, findParent} from './../../util.js';
  * @test {ParamParser#parseParam}
  */
 describe('TestTypeUnion', ()=> {
-  const doc = readDoc('class/src/Type/Union.js~TestTypeUnion.html');
+  const doc = readDoc('class/src/Type/Union.js~TestTypeUnion.html', 'Type');
 
   it('has union type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypedefTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypedefTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {TypedefDoc} */
 describe('TestTypedefDefinition', ()=> {
-  const doc = readDoc('typedef/index.html');
+  const doc = readDoc('typedef/index.html', 'Typedef');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/UndocumentTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/UndocumentTest/DefinitionTest.js
@@ -6,7 +6,7 @@ import {readDoc, assert} from './../../util.js';
  * @test {DocResolver#_resolveUndocumentIdentifier}
  */
 describe('TestUndocumentDefinition', ()=> {
-  const doc = readDoc('class/src/Undocument/Definition.js~TestUndocumentDefinition.html');
+  const doc = readDoc('class/src/Undocument/Definition.js~TestUndocumentDefinition.html', 'Undocument');
 
   it('is exist', ()=> {
     assert.includes(doc, '.self-detail [data-ice="name"]', 'TestUndocumentDefinition');

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ArrayPatterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ArrayPatterTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableArrayPattern', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Variable/variable/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ArrayPatterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ArrayPatterTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableArrayPattern', ()=> {
-  const doc = readDoc('Variable/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Variable');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableDefinition', ()=> {
-  const doc = readDoc('Variable/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Variable');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/DefinitionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/DefinitionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableDefinition', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Variable/variable/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ObjectPatterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ObjectPatterTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableObjectPattern', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Variable/variable/index.html');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ObjectPatterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VariableTest/ObjectPatterTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {VariableDoc} */
 describe('testVariableObjectPattern', ()=> {
-  const doc = readDoc('Variable/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Variable');
 
   describe('in summary', ()=> {
     it('has desc', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/ClassTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/ClassTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@version} */
 describe('TestVersionClass', ()=> {
-  const doc = readDoc('class/src/Version/Class.js~TestVersionClass.html');
+  const doc = readDoc('class/src/Version/Class.js~TestVersionClass.html', 'Version');
 
   describe('in self detail', ()=> {
     it('has version.', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@version} */
 describe('testVersionFunction', ()=> {
-  const doc = readDoc('Version/function/index.html');
+  const doc = readDoc('function/index.html', 'Version');
 
   describe('in summary', ()=> {
     it('has version', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/FunctionTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@version} */
 describe('testVersionFunction', ()=> {
-  const doc = readDoc('function/index.html');
+  const doc = readDoc('Version/function/index.html');
 
   describe('in summary', ()=> {
     it('has version', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@version} */
 describe('testVersionVariable', ()=> {
-  const doc = readDoc('Version/variable/index.html');
+  const doc = readDoc('variable/index.html', 'Version');
 
   describe('in summary', ()=> {
     it('has version', ()=> {

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/VariableTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/VersionTest/VariableTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../../util.js';
 
 /** @test {AbstractDoc#@version} */
 describe('testVersionVariable', ()=> {
-  const doc = readDoc('variable/index.html');
+  const doc = readDoc('Version/variable/index.html');
 
   describe('in summary', ()=> {
     it('has version', ()=> {

--- a/esdoc-publish-html-plugin/test/src/NavTest/NavTest.js
+++ b/esdoc-publish-html-plugin/test/src/NavTest/NavTest.js
@@ -5,31 +5,31 @@ describe('test navigation:', ()=> {
   const doc = readDoc('index.html');
 
   it('has class', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="class/src/Desc/Class.js~TestDescClass.html"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href$="class/src/Desc/Class.js~TestDescClass.html"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'TestDescClass');
     });
   });
 
   it('has interface.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="class/src/Interface/Definition.js~TestInterfaceDefinition.html"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href$="class/src/Interface/Definition.js~TestInterfaceDefinition.html"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'TestInterfaceDefinition');
     });
   });
 
   it('has function.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="Desc/function/index.html#static-function-testDescFunction"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href$="function/index.html#static-function-testDescFunction"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'testDescFunction');
     });
   });
 
   it('has variable.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="Desc/variable/index.html#static-variable-testDescVariable"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href$="variable/index.html#static-variable-testDescVariable"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'testDescVariable');
     });
   });
 
   it('has typedef.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="typedef/index.html#static-typedef-TestTypedefDefinition"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href$="typedef/index.html#static-typedef-TestTypedefDefinition"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'TestTypedefDefinition');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/NavTest/NavTest.js
+++ b/esdoc-publish-html-plugin/test/src/NavTest/NavTest.js
@@ -17,13 +17,13 @@ describe('test navigation:', ()=> {
   });
 
   it('has function.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="function/index.html#static-function-testDescFunction"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href="Desc/function/index.html#static-function-testDescFunction"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'testDescFunction');
     });
   });
 
   it('has variable.', ()=>{
-    findParent(doc, '[data-ice="nav"] a[href="variable/index.html#static-variable-testDescVariable"]', '[data-ice="doc"]', (doc)=>{
+    findParent(doc, '[data-ice="nav"] a[href="Desc/variable/index.html#static-variable-testDescVariable"]', '[data-ice="doc"]', (doc)=>{
       assert.includes(doc, null, 'testDescVariable');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/SearchTest/SearchTest.js
+++ b/esdoc-publish-html-plugin/test/src/SearchTest/SearchTest.js
@@ -1,15 +1,20 @@
 import fs from 'fs';
 import assert from 'assert';
+import { pluginOptions } from './../util';
 
 describe('test search', ()=>{
   const searchIndexJS = fs.readFileSync('./test/fixture/out/script/search_index.js', {encoding: 'utf8'}).toString();
   const searchIndexJSON = searchIndexJS.replace('window.esdocSearchIndex = ', '');
   const searchIndex = JSON.parse(searchIndexJSON);
 
-  function find(searchIndex, url) {
+  function find(searchIndex, url, path) {
+    url = (pluginOptions.organizePaths && path) ? `${path}/${url}` : url;
     const results = [];
     for (const item of searchIndex) {
-      if (item[1] === url) results.push(item);
+      if (item[1] === url) {
+        item[1] = (pluginOptions.organizePaths && path) ? item[1].replace(new RegExp(`^${path}/`), '') : item[1];
+        results.push(item);
+      }
     }
 
     if (results.length > 1) assert(false, `some ${url} found. results = ${results}`);
@@ -18,7 +23,7 @@ describe('test search', ()=>{
   }
 
   it('has class index', ()=>{
-    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html'), [
+    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html', 'Desc'), [
       'esdoc-test-fixture/src/desc/class.js~testdescclass',
       'class/src/Desc/Class.js~TestDescClass.html',
       '<span>TestDescClass</span> <span class="search-result-import-path">esdoc-test-fixture/src/Desc/Class.js</span>',
@@ -27,7 +32,7 @@ describe('test search', ()=>{
   });
 
   it('has member index', ()=>{
-    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html#instance-member-p1'), [
+    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html#instance-member-p1', 'Desc'), [
       'src/desc/class.js~testdescclass#p1',
       'class/src/Desc/Class.js~TestDescClass.html#instance-member-p1',
       'src/Desc/Class.js~TestDescClass#p1',
@@ -36,7 +41,7 @@ describe('test search', ()=>{
   });
 
   it('has method index', ()=>{
-    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html#instance-method-method1'), [
+    assert.deepEqual(find(searchIndex, 'class/src/Desc/Class.js~TestDescClass.html#instance-method-method1', 'Desc'), [
       'src/desc/class.js~testdescclass#method1',
       'class/src/Desc/Class.js~TestDescClass.html#instance-method-method1',
       'src/Desc/Class.js~TestDescClass#method1',
@@ -45,7 +50,7 @@ describe('test search', ()=>{
   });
 
   it('has interface index', ()=>{
-    assert.deepEqual(find(searchIndex, 'class/src/Interface/Definition.js~TestInterfaceDefinition.html'), [
+    assert.deepEqual(find(searchIndex, 'class/src/Interface/Definition.js~TestInterfaceDefinition.html', 'Interface'), [
       'esdoc-test-fixture/src/interface/definition.js~testinterfacedefinition',
       'class/src/Interface/Definition.js~TestInterfaceDefinition.html',
       '<span>TestInterfaceDefinition</span> <span class="search-result-import-path">esdoc-test-fixture/src/Interface/Definition.js</span>',
@@ -54,25 +59,25 @@ describe('test search', ()=>{
   });
 
   it('has function index', ()=>{
-    assert.deepEqual(find(searchIndex, 'Desc/function/index.html#static-function-testDescFunction'), [
+    assert.deepEqual(find(searchIndex, 'function/index.html#static-function-testDescFunction', 'Desc'), [
       'esdoc-test-fixture/src/desc/function.js~testdescfunction',
-      'Desc/function/index.html#static-function-testDescFunction',
+      'function/index.html#static-function-testDescFunction',
       '<span>testDescFunction</span> <span class="search-result-import-path">esdoc-test-fixture/src/Desc/Function.js</span>',
       'function'
     ]);
   });
 
   it('has variable index', ()=>{
-    assert.deepEqual(find(searchIndex, 'Desc/variable/index.html#static-variable-testDescVariable'), [
+    assert.deepEqual(find(searchIndex, 'variable/index.html#static-variable-testDescVariable', 'Desc'), [
       'esdoc-test-fixture/src/desc/variable.js~testdescvariable',
-      'Desc/variable/index.html#static-variable-testDescVariable',
+      'variable/index.html#static-variable-testDescVariable',
       '<span>testDescVariable</span> <span class="search-result-import-path">esdoc-test-fixture/src/Desc/Variable.js</span>',
       'variable'
     ]);
   });
 
   it('has typedef index', ()=>{
-    assert.deepEqual(find(searchIndex, 'typedef/index.html#static-typedef-TestTypedefDefinition'), [
+    assert.deepEqual(find(searchIndex, 'typedef/index.html#static-typedef-TestTypedefDefinition', 'Typedef'), [
       'src/typedef/definition.js~testtypedefdefinition',
       'typedef/index.html#static-typedef-TestTypedefDefinition',
       'src/Typedef/Definition.js~TestTypedefDefinition',

--- a/esdoc-publish-html-plugin/test/src/SearchTest/SearchTest.js
+++ b/esdoc-publish-html-plugin/test/src/SearchTest/SearchTest.js
@@ -54,18 +54,18 @@ describe('test search', ()=>{
   });
 
   it('has function index', ()=>{
-    assert.deepEqual(find(searchIndex, 'function/index.html#static-function-testDescFunction'), [
+    assert.deepEqual(find(searchIndex, 'Desc/function/index.html#static-function-testDescFunction'), [
       'esdoc-test-fixture/src/desc/function.js~testdescfunction',
-      'function/index.html#static-function-testDescFunction',
+      'Desc/function/index.html#static-function-testDescFunction',
       '<span>testDescFunction</span> <span class="search-result-import-path">esdoc-test-fixture/src/Desc/Function.js</span>',
       'function'
     ]);
   });
 
   it('has variable index', ()=>{
-    assert.deepEqual(find(searchIndex, 'variable/index.html#static-variable-testDescVariable'), [
+    assert.deepEqual(find(searchIndex, 'Desc/variable/index.html#static-variable-testDescVariable'), [
       'esdoc-test-fixture/src/desc/variable.js~testdescvariable',
-      'variable/index.html#static-variable-testDescVariable',
+      'Desc/variable/index.html#static-variable-testDescVariable',
       '<span>testDescVariable</span> <span class="search-result-import-path">esdoc-test-fixture/src/Desc/Variable.js</span>',
       'variable'
     ]);

--- a/esdoc-publish-html-plugin/test/src/TestTest/TestLinkTest.js
+++ b/esdoc-publish-html-plugin/test/src/TestTest/TestLinkTest.js
@@ -2,7 +2,7 @@ import {readDoc, assert, findParent} from './../util.js';
 
 /** @test {ClassDocBuilder} */
 describe('test link of test', ()=>{
-  const doc = readDoc('class/src/Desc/Class.js~TestDescClass.html');
+  const doc = readDoc('class/src/Desc/Class.js~TestDescClass.html', 'Desc');
 
   it('has link of test at class', ()=>{
     assert.multiIncludes(doc, '.self-detail [data-ice="test"] a', [

--- a/esdoc-publish-html-plugin/test/src/util.js
+++ b/esdoc-publish-html-plugin/test/src/util.js
@@ -1,6 +1,8 @@
 import _assert from 'assert';
 import fs from 'fs';
 import cheerio from 'cheerio';
+import path from 'path';
+import PluginOptions from './../../src/PluginOptions';
 // import path from 'path';
 // import ESDocCLI from '../../src/ESDocCLI.js';
 
@@ -20,8 +22,25 @@ import cheerio from 'cheerio';
 //   consoleLogSwitch(true);
 // }
 
-export function readDoc(fileName, dirName = './test/fixture/out') {
-  const html = fs.readFileSync(`${dirName}/${fileName}`, {encoding: 'utf-8'});
+//Get our options
+const esdocJSON = path.join(__dirname, '../fixture/esdoc.json');
+let _pluginOptions = PluginOptions;
+try {
+  const parsed = JSON.parse(fs.readFileSync(esdocJSON).toString());
+  parsed.plugins.some((plugin) => {
+    if (plugin.name === './src/Plugin.js') {
+      _pluginOptions = plugin.option || PluginOptions;
+      return true;
+    }
+  });
+} catch (e) {
+  _pluginOptions = PluginOptions;
+}
+export const pluginOptions = _pluginOptions;
+
+export function readDoc(fileName, filePath = '', dirName = './test/fixture/out') {
+  filePath = (_pluginOptions.organizePaths && filePath.length) ? `${filePath}/` : '';
+  const html = fs.readFileSync(`${dirName}/${filePath}${fileName}`, {encoding: 'utf-8'});
   const $ = cheerio.load(html);
   return $('html').first();
 }


### PR DESCRIPTION
Currently ESDoc is putting all non-member functions, variables, and typedefs into the same "KIND/index.html" folder. This can lead to conflicts when module A exports the same function as module B.

This fix allows ESDoc to build non-member single pages based on the file paths for better documentation separation.

**Example**:
./moduleA.js -> exports async function configure();
./pluginB/moduleB.js -> exports async function configure();

**Before**:
This would put both configure() functions in "docs/function/index.html"

**Now**:
Two files are created, each now containing the correct configure() function:
./docs/function/index.html: Lists moduleA configure()
./docs/pluginB/function/index.html: Lists moduleB configure()