### PR TITLE
feat(importpath): Add option.stripPackageName

### DIFF
--- a/esdoc-importpath-plugin/README.md
+++ b/esdoc-importpath-plugin/README.md
@@ -17,6 +17,7 @@ Therefore, convert the import path by using following setting.
     {
       "name": "esdoc-importpath-plugin",
       "option": {
+        "stripPackageName": false,
         "replaces": [
           {"from": "^src/", "to": "lib/"}
         ]
@@ -32,6 +33,10 @@ When writing multi rules, it will also be carried out transformation many times.
 For example, ``[{from: "^src/", to: "lib/"}, {from: "MyFooClass", to: "my-foo"}]`` converted as follows:
 
 - `` my-module/src/MyFooClass.js`` => `` my-module/lib/MyFooClass.js`` => ``my-module/lib/my-foo``
+
+``stripPackageName`` is a boolean that when set to ``true`` will strip the package name from the import path.
+
+This is useful for projects that have custom module resolvers where you want to be able to replace the whole path.
 
 ## Install
 ```sh

--- a/esdoc-importpath-plugin/src/Plugin.js
+++ b/esdoc-importpath-plugin/src/Plugin.js
@@ -37,7 +37,7 @@ class Plugin {
 
       if (importPath === mainPath) {
         doc.importPath = packageName;
-      } else if (packageName) {
+      } else if (packageName && option.stripPackageName !== true) {
         doc.importPath = `${packageName}/${importPath}`;
       } else {
         doc.importPath = importPath;


### PR DESCRIPTION
Add a `stripPackageName: true` option to the importpath plugin to allow stripping the package name from the import path.

This is useful for projects that have custom module resolvers where you want to be able to replace the whole path.