### PR TITLE
Much improved type reconstruction from Flow annotations.

### DIFF
--- a/esdoc-flow-type-plugin/src/Plugin.js
+++ b/esdoc-flow-type-plugin/src/Plugin.js
@@ -190,17 +190,26 @@ class FlowTypePlugin {
   _getTypeFromAnnotation(typeAnnotation) {
     if (!typeAnnotation) return '*';
 
-    let type;
-    switch (typeAnnotation.typeAnnotation.type) {
-      case 'GenericTypeAnnotation':
-        type = typeAnnotation.typeAnnotation.id.name;
-        break;
-      default:
-        type = typeAnnotation.typeAnnotation.type.replace('TypeAnnotation', '').toLowerCase();
-        break;
+    function formatTypeAnnotations(types, sep) {
+      return types.map(formatTypeAnnotation).join(sep);
     }
-
-    return type;
+    function formatTypeAnnotation(type) {
+      switch (type.type) {
+        case 'GenericTypeAnnotation':
+          return type.typeParameters ?
+            `${type.id.name}<${formatTypeAnnotations(type.typeParameters.params, ', ')}>` :
+            type.id.name;
+        case 'TupleTypeAnnotation':
+          return `[${formatTypeAnnotations(type.types, ', ')}]`;
+        case 'NullableTypeAnnotation':
+          return `?${formatTypeAnnotation(type.typeAnnotation)}`;
+        case 'UnionTypeAnnotation':
+          return formatTypeAnnotations(type.types, '|');
+        default:
+          return type.type.replace('TypeAnnotation', '').toLowerCase();
+      }
+    }
+    return formatTypeAnnotation(typeAnnotation.typeAnnotation);
   }
 }
 

--- a/esdoc-flow-type-plugin/src/Plugin.js
+++ b/esdoc-flow-type-plugin/src/Plugin.js
@@ -190,6 +190,16 @@ class FlowTypePlugin {
   _getTypeFromAnnotation(typeAnnotation) {
     if (!typeAnnotation) return '*';
 
+    function formatTypeId(id) {
+      switch (id.type) {
+        case 'QualifiedTypeIdentifier':
+          return `${formatTypeId(id.qualification)}.${formatTypeId(id.id)}`;
+        case 'Identifier':
+          return id.name;
+        default:
+          return id.type;
+      }
+    }
     function formatTypeAnnotations(types, sep) {
       return types.map(formatTypeAnnotation).join(sep);
     }
@@ -197,8 +207,8 @@ class FlowTypePlugin {
       switch (type.type) {
         case 'GenericTypeAnnotation':
           return type.typeParameters ?
-            `${type.id.name}<${formatTypeAnnotations(type.typeParameters.params, ', ')}>` :
-            type.id.name;
+            `${formatTypeId(type.id)}<${formatTypeAnnotations(type.typeParameters.params, ', ')}>` :
+            formatTypeId(type.id);
         case 'TupleTypeAnnotation':
           return `[${formatTypeAnnotations(type.types, ', ')}]`;
         case 'NullableTypeAnnotation':

--- a/esdoc-flow-type-plugin/test/src/FlowType.js
+++ b/esdoc-flow-type-plugin/test/src/FlowType.js
@@ -26,6 +26,18 @@ export class TestFlowTypeClass {
   method3(n: number, x: Foo): string {
     return 'Hello'.repeat(n);
   }
+
+  /**
+   * this is method4.
+   * @param t - this is t
+   * @param x - this is x
+   * @param o - this is o
+   * @param q - this is q
+   * @return this is return
+   */
+  method4(t: [number, number], x: Foo<string>, o: string|void, q: THREE.Vector3): ?string {
+    return 'Hello'.repeat(t[0]);
+  }
 }
 
 export function testFlowTypeFunction(n: number, x: Foo): string{}

--- a/esdoc-flow-type-plugin/test/src/FlowType.test.js
+++ b/esdoc-flow-type-plugin/test/src/FlowType.test.js
@@ -30,6 +30,18 @@ describe('test/FlowType.js:', ()=> {
     assert.deepEqual(doc.return.types, ['string']);
   });
 
+  it('has type of method, extracting proper argument types', ()=>{
+    const doc = find('longname', 'src/FlowType.js~TestFlowTypeClass#method4');
+    assert.equal(doc.params.length, 4);
+    assert.deepEqual(doc.params[0].types, ['[number, number]']);
+    assert.deepEqual(doc.params[1].types, ['Foo<string>']);
+    assert.deepEqual(doc.params[2].types, ['string' , 'void']);
+    assert.deepEqual(doc.params[3].types, ['THREE.Vector3']);
+
+    assert.deepEqual(doc.return.types, ['string']);
+    assert.equal(doc.return.nullable, true);
+  });
+
   it('has type of getter, without comment', ()=>{
     const doc = find('longname', 'src/FlowType.js~TestFlowTypeClass#getter1');
     assert.deepEqual(doc.type.types, ['string']);


### PR DESCRIPTION
- includes generic parameters: Foo<Bar, Baz>
- handles tuple types: [string, number]
- handles union types: string | void
- handles nullable types: ?string