### PR TITLE
Fix error when esdoc-lint-plugin is disabled

### DIFF
--- a/esdoc-lint-plugin/src/Plugin.js
+++ b/esdoc-lint-plugin/src/Plugin.js
@@ -161,6 +161,7 @@ class Plugin {
   }
 
   _showResult() {
+    if (!this._option.enable) return;
     for (const result of this._results) {
       console.log(`[33mwarning: signature mismatch: ${result.name} ${result.filePath}#${result.lines[0].lineNumber}[32m`);
       for (const line of result.lines) {


### PR DESCRIPTION
This plugins initializes the linting results (`this._results`) to `null`.

If this plugin is enabled, `this._results` is set to a new array when the `onPublish` event is handled. But when the plugin is disabled, `this._results` will never change and will remain set to `null`. This will cause an error when Esdoc tries to iterate over the linting results in: `for (const result of this._results) `

This change checks if the plugin is disabled and returns early, before showing the results.