### PR TITLE
typescript: Fix crash on `getTypeFromAnnotation` | Interfaces?

### DIFF
--- a/esdoc-typescript-plugin/src/Plugin.js
+++ b/esdoc-typescript-plugin/src/Plugin.js
@@ -240,6 +240,10 @@ class Plugin {
   }
 
   _getTypeFromAnnotation(typeNode) {
+    if (!typeNode) {
+      return 'undefined';
+    }
+
     switch(typeNode.kind) {
       case ts.SyntaxKind.NumberKeyword: return 'number';
       case ts.SyntaxKind.StringKeyword: return 'string';


### PR DESCRIPTION
Hi!

Tbh i have no idea about what i'm doing here. But I would just love however to use **esdoc** with *TypeScript*. :rocket: 

When using the plugin on our code, it crashes like below (stacktrace appended).

This patch here fixes the crash, but I have no idea about the side-effects.

We get a proper documentation now. But maybe we are missing some things though we are not aware of.

Also, what I saw is that I don't get interfaces in the docs. Is that maybe one of missing features or side-effects of this quick fix? :hear_no_evil: :boom: 

Maybe, with anybodies assistence here, we could contribute to have Typescript interfaces be handled as well :) :+1: 

```
TypeError: Cannot read property 'kind' of undefined
    at Plugin._getTypeFromAnnotation (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:253:20)
    at node.parameters.map.param (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:141:20)
    at Array.map (native)
    at Plugin._applyCallableParam (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:139:35)
    at Plugin._transpileComment (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:105:14)
    at Plugin._tsParser (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:56:31)
    at ev.data.parser.e (/media/stephan/PLAYGROUND/Code/esdoc-plugins/esdoc-typescript-plugin/src/Plugin.js:33:21)
    at Function.parse (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/Parser/ESParser.js:47:15)
    at Function._traverse (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:225:32)
    at _walk.filePath (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:114:25)
/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/Factory/DocFactory.js:136
    for (const exportNode of this._ast.program.body) {
                                      ^

TypeError: Cannot read property 'program' of undefined
    at DocFactory._inspectExportDefaultDeclaration (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/Factory/DocFactory.js:136:39)
    at new DocFactory (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/Factory/DocFactory.js:91:10)
    at Function._traverse (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:232:21)
    at _walk.filePath (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:114:25)
    at Function._walk (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:203:9)
    at Function.generate (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDoc.js:98:10)
    at ESDocCLI.exec (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDocCLI.js:71:23)
    at Object.<anonymous> (/media/stephan/PLAYGROUND/Code/pantaflix/rappertunie/node_modules/esdoc/out/src/ESDocCLI.js:182:7)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
```

