### PR TITLE
Fail gracefully when splitting by comma doesn't work.

### DIFF
--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -676,9 +676,15 @@ export default class DocBuilder {
         .replace(/<.*?>/g, (a)=> a.replace(/,/g, '\\Z'))
         .replace(/{.*?}/g, (a)=> a.replace(/,/g, '\\Z').replace(/:/g, '\\Y'));
       const innerTypes = inner.split(',').map((v)=>{
-        const tmp = v.split(':').map((v)=> v.trim());
-        const paramName = tmp[0];
-        let typeName = tmp[1].replace(/\\Z/g, ',').replace(/\\Y/g, ':');
+        let tmp, paramName, typeName = '';
+        try {
+          tmp = v.split(':').map((v)=> v.trim());
+          paramName = tmp[0];
+          typeName = tmp[1].replace(/\\Z/g, ',').replace(/\\Y/g, ':');
+        } catch (e) {
+          // no-op, fail gracefully
+        }
+
         if (typeName.includes('|')) {
           typeName = typeName.replace(/^\(/, '').replace(/\)$/, '');
           const typeNames = typeName.split('|').map(v => v.trim());


### PR DESCRIPTION
I know it's an edge case, but one of our exported objects has a key with a comma in it (don't ask), and it causes this to fail. I'm ok excluding it from the generated documentation (like I said, huge edge case) so this try/catch block makes it so it at least finishes the html publishing.