### PR TITLE
Fix issue on "named" default exports.

### DIFF
--- a/esdoc-type-inference-plugin/src/Plugin.js
+++ b/esdoc-type-inference-plugin/src/Plugin.js
@@ -77,6 +77,8 @@ class Plugin {
       if (doc.type) continue;
 
       const node = ASTNodeContainer.getNode(doc.__docId__);
+      if (!node.declarations) continue;
+
       if (node.declarations[0].init.type === 'NewExpression') {
         const className = node.declarations[0].init.callee.name;
 


### PR DESCRIPTION
Hello,

I encountered an issue because I wanted to document default exports and was hoping to succeed with code such as:

```javascript
// some api.js module
class Api {...}

// my default Api client instance I want to document
export default api = new Api(host);
```

This is valid ES6, but it the plugin crashes:

```
$ esdoc -c esdoc.json
/.../node_modules/esdoc-type-inference-plugin/src/Plugin.js:80
      if (node.declarations[0].init.type === 'NewExpression') {
                           ^

TypeError: Cannot read property '0' of undefined
    at Plugin._inferenceVariable (/.../node_modules/esdoc-type-inference-plugin/src/Plugin.js:80:28)
    at Plugin._exec (/.../node_modules/esdoc-type-inference-plugin/src/Plugin.js:22:10)
    at Plugin.onHandleDocs (/.../node_modules/esdoc-type-inference-plugin/src/Plugin.js:11:10)
    at Plugin._execHandler (/.../node_modules/esdoc/out/src/Plugin/Plugin.js:55:26)
    at Plugin.onHandleDocs (/.../node_modules/esdoc/out/src/Plugin/Plugin.js:135:10)
    at Function.generate (/.../node_modules/esdoc/out/src/ESDoc.js:133:32)
    at ESDocCLI.exec (/.../node_modules/esdoc/out/src/ESDocCLI.js:71:23)
    at Object.<anonymous> (/.../node_modules/esdoc/out/src/ESDocCLI.js:182:7)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
```

This 1-line patch fixes this issue.
_(see the commit patch/message for some more details)_

Regards !