### PR TITLE
[esdoc-react-plugin] [windows] Support Windows file paths

### DIFF
--- a/esdoc-react-plugin/src/Plugin.js
+++ b/esdoc-react-plugin/src/Plugin.js
@@ -40,13 +40,13 @@ class Plugin {
     // find target doc
     const doc = this._reactPropsDocs.find(doc => {
       const regexp = new RegExp(`${doc.fileName}$`);
-      if (fileName.match(regexp)) return true;
+      if (fileName.replace(/\\/g, '/').match(regexp)) return true;
     });
     if (!doc) return;
 
     // create esdoc properties from react props
     const properties = doc.reactProps.map(reactProp => {
-      const {typeText, paramName, paramDesc} = ParamParser.parseParamValue(reactProp.tagValue);
+      const { typeText, paramName, paramDesc } = ParamParser.parseParamValue(reactProp.tagValue);
       return ParamParser.parseParam(typeText, paramName, paramDesc);
     });
 


### PR DESCRIPTION
Hello!

This one fixes the problem on Windows systems where `.match(regexp)` will always return `null` because of forward/backward slash difference in file paths.
I was not able to find an issue filed related to this problem. Please, link it if it exists.