### PR TITLE
Remove 'en-US' prefixes from the URLs to MDN docs

### DIFF
--- a/esdoc-external-ecmascript-plugin/src/external-ecmascript.js
+++ b/esdoc-external-ecmascript-plugin/src/external-ecmascript.js
@@ -1,192 +1,192 @@
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
 
 // Value properties
 /**
- * @external {Infinity} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity
+ * @external {Infinity} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Infinity
  */
 
 /**
- * @external {NaN} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN
+ * @external {NaN} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN
  */
 
 /**
- * @external {undefined} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined
+ * @external {undefined} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
  */
 
 /**
- * @external {null} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null
+ * @external {null} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/null
  */
 
 // Fundamental objects
 /**
- * @external {Object} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+ * @external {Object} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
  */
 /**
- * @external {object} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
- */
-
-/**
- * @external {Function} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
- */
-/**
- * @external {function} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
+ * @external {object} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
  */
 
 /**
- * @external {Boolean} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+ * @external {Function} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function
  */
 /**
- * @external {boolean} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
- */
-
-/**
- * @external {Symbol} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+ * @external {function} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function
  */
 
 /**
- * @external {Error} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+ * @external {Boolean} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+ */
+/**
+ * @external {boolean} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
  */
 
 /**
- * @external {EvalError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
+ * @external {Symbol} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol
  */
 
 /**
- * @external {InternalError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/InternalError
+ * @external {Error} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
  */
 
 /**
- * @external {RangeError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError
+ * @external {EvalError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError
  */
 
 /**
- * @external {ReferenceError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
+ * @external {InternalError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/InternalError
  */
 
 /**
- * @external {SyntaxError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
+ * @external {RangeError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError
  */
 
 /**
- * @external {TypeError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
+ * @external {ReferenceError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
  */
 
 /**
- * @external {URIError} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError
+ * @external {SyntaxError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
+ */
+
+/**
+ * @external {TypeError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError
+ */
+
+/**
+ * @external {URIError} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError
  */
 
 // Numbers and dates
 /**
- * @external {Number} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
+ * @external {Number} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
  */
 /**
- * @external {number} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
+ * @external {number} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
  */
 
 /**
- * @external {Date} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
+ * @external {Date} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
  */
 
 // Text processing
 /**
- * @external {String} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
+ * @external {String} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
  */
 /**
- * @external {string} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
+ * @external {string} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
  */
 
 /**
- * @external {RegExp} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+ * @external {RegExp} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp
  */
 
 // Indexed collections
 /**
- * @external {Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+ * @external {Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
  */
 
 /**
- * @external {Int8Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
+ * @external {Int8Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
  */
 /**
- * @external {Uint8Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
- */
-
-/**
- * @external {Uint8ClampedArray} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
+ * @external {Uint8Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
  */
 
 /**
- * @external {Int16Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
+ * @external {Uint8ClampedArray} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
  */
 
 /**
- * @external {Uint16Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array
+ * @external {Int16Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
  */
 
 /**
- * @external {Int32Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
+ * @external {Uint16Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array
  */
 
 /**
- * @external {Uint32Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
+ * @external {Int32Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
  */
 
 /**
- * @external {Float32Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+ * @external {Uint32Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
  */
 
 /**
- * @external {Float64Array} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
+ * @external {Float32Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+ */
+
+/**
+ * @external {Float64Array} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
  */
 
 // Keyed collections
 /**
- * @external {Map} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+ * @external {Map} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map
  */
 
 /**
- * @external {Set} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+ * @external {Set} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set
  */
 
 /**
- * @external {WeakMap} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+ * @external {WeakMap} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
  */
 
 /**
- * @external {WeakSet} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
+ * @external {WeakSet} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
  */
 
 // Structured data
 /**
- * @external {ArrayBuffer} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+ * @external {ArrayBuffer} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
  */
 
 /**
- * @external {DataView} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
+ * @external {DataView} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView
  */
 
 /**
- * @external {JSON} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
+ * @external {JSON} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON
  */
 
 // Control abstraction objects
 /**
- * @external {Promise} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+ * @external {Promise} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
  */
 
 /**
- * @external {Generator} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator
+ * @external {Generator} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator
  */
 
 /**
- * @external {GeneratorFunction} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction
+ * @external {GeneratorFunction} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction
  */
 
 // Reflection
 /**
- * @external {Reflect} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect
+ * @external {Reflect} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect
  */
 
 /**
- * @external {Proxy} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
+ * @external {Proxy} https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy
  */

--- a/esdoc-external-ecmascript-plugin/test/src/MyClass.test.js
+++ b/esdoc-external-ecmascript-plugin/test/src/MyClass.test.js
@@ -8,7 +8,7 @@ describe('test external ecmascript results:', ()=>{
 
   it('has external ecmascript.', ()=>{
     const tag = tags.find(tag => tag.kind === 'external' && tag.name === 'number');
-    assert.equal(tag.externalLink, "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number");
+    assert.equal(tag.externalLink, "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number");
   });
 
   it('removed external-ecmascript.js', ()=>{

--- a/esdoc-external-nodejs-plugin/src/external-nodejs.js
+++ b/esdoc-external-nodejs-plugin/src/external-nodejs.js
@@ -1,4 +1,4 @@
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
 
 // Value properties
 /**

--- a/esdoc-external-webapi-plugin/src/external-webapi.js
+++ b/esdoc-external-webapi-plugin/src/external-webapi.js
@@ -1,27 +1,27 @@
-// https://developer.mozilla.org/en-US/docs/Web/API
+// https://developer.mozilla.org/docs/Web/API
 
 /**
- * @external {CanvasRenderingContext2D} https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D
+ * @external {CanvasRenderingContext2D} https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D
  */
 
 /**
- * @external {DocumentFragment} https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
+ * @external {DocumentFragment} https://developer.mozilla.org/docs/Web/API/DocumentFragment
  */
 
 /**
- * @external {Element} https://developer.mozilla.org/en-US/docs/Web/API/Element
+ * @external {Element} https://developer.mozilla.org/docs/Web/API/Element
  */
 
 /**
- * @external {Event} https://developer.mozilla.org/en-US/docs/Web/API/Event
+ * @external {Event} https://developer.mozilla.org/docs/Web/API/Event
  */
 
 /**
- * @external {Node} https://developer.mozilla.org/en-US/docs/Web/API/Node
+ * @external {Node} https://developer.mozilla.org/docs/Web/API/Node
  */
 
 /**
- * @external {NodeList} https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+ * @external {NodeList} https://developer.mozilla.org/docs/Web/API/NodeList
  */
 
 /**

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/BuiltinTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/BuiltinTest.js
@@ -8,7 +8,7 @@ describe('TestExtendsBuiltin', ()=> {
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{
       assert.includes(doc, null, 'Array → TestExtendsBuiltin');
       assert.includes(doc, 'a', 'Array');
-      assert.includes(doc, 'a', 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array', 'href');
+      assert.includes(doc, 'a', 'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array', 'href');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/OuterTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/ExtendsTest/OuterTest.js
@@ -7,7 +7,7 @@ describe('TestExtendsOuter', ()=> {
   it('has extends chain.', ()=> {
     find(doc, '.self-detail [data-ice="extendsChain"]', (doc)=>{
       assert.includes(doc, null, 'Array → TestExtendsBuiltin → TestExtendsOuter');
-      assert.includes(doc, 'a[href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"]', 'Array');
+      assert.includes(doc, 'a[href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array"]', 'Array');
       assert.includes(doc, 'a[href="class/src/Extends/Builtin.js~TestExtendsBuiltin.html"]', 'TestExtendsBuiltin');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ComplexTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ComplexTest.js
@@ -11,12 +11,12 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: function(x1: number[], x2: Map<string, boolean>): Object)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object'
       ], 'href');
     });
   });
@@ -25,9 +25,9 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method2"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method2(p1: Map<number, string[]>)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
       ], 'href');
     });
   });
@@ -36,12 +36,12 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method3"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method3(p1: {x1: number[], x2: Map<string, boolean>, x3: {y1: number, y2: string}})');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
       ], 'href');
     });
   });
@@ -50,10 +50,10 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method4"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method4(p1: number | string, p2: number | string)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
       ], 'href');
     });
   });
@@ -62,10 +62,10 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method5"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method5(p1: Promise<string|number, Error>)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error'
       ], 'href');
     });
   });
@@ -74,8 +74,8 @@ describe('TestTypeComplex', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method6"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method6(p1: ...(number|string))');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ExternalTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ExternalTest.js
@@ -10,7 +10,7 @@ describe('TestTypeExternal', ()=> {
   it('has external type.', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: ArrayBuffer)');
-      assert.includes(doc, 'a[href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"]', 'ArrayBuffer');
+      assert.includes(doc, 'a[href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"]', 'ArrayBuffer');
     });
   });
 });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/FunctionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/FunctionTest.js
@@ -11,10 +11,10 @@ describe('TestTypeFunction', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: function(x1: number, x2: string): boolean)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/GenericsTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/GenericsTest.js
@@ -11,14 +11,14 @@ describe('TestTypeGenerics', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: Array<number>, p2: Map<number, string>, p3: Promise<number[], Error>)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/LiteralTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/LiteralTest.js
@@ -11,9 +11,9 @@ describe('TestTypeLiteral', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: number, p2: string, p3: boolean)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ObjectTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/ObjectTest.js
@@ -11,7 +11,7 @@ describe('TestTypeObject', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: Object)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/RecordTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/RecordTest.js
@@ -11,8 +11,8 @@ describe('TestTypeRecord', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: {x1: number, x2: string})');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/SpreadTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/SpreadTest.js
@@ -11,7 +11,7 @@ describe('TestTypeSpread', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: ...number)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number'
       ], 'href');
     });
   });
@@ -20,7 +20,7 @@ describe('TestTypeSpread', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method2"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method2(config: Object)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object'
       ], 'href');
     });
   });

--- a/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/UnionTest.js
+++ b/esdoc-publish-html-plugin/test/src/DocumentTest/TypeTest/UnionTest.js
@@ -11,8 +11,8 @@ describe('TestTypeUnion', ()=> {
     findParent(doc, '[data-ice="summary"] [href$="#instance-method-method1"]', '[data-ice="target"]', (doc)=> {
       assert.includes(doc, null, 'method1(p1: number | string)');
       assert.multiIncludes(doc, '[data-ice="signature"] a', [
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number',
-        'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number',
+        'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String'
       ], 'href');
     });
   });


### PR DESCRIPTION
Thank you for making very useful documentation tools! 😊

This PR changes the prefix of URLs to MDN docs from `https://developer.mozilla.org/en-US/docs/` to `https://developer.mozilla.org/docs/` in 3 external-plugins.

When accessing MDN docs without `/en-US/` prefix, the site redirects the user to the localized one by auto-detecting or using saved language by user. So this eases document readers to read documents generated by ESDoc more.