### PR TITLE
Setup overflow for code

### DIFF
--- a/esdoc-publish-html-plugin/src/Builder/template/css/style.css
+++ b/esdoc-publish-html-plugin/src/Builder/template/css/style.css
@@ -89,6 +89,7 @@ code {
 
 pre > code {
   display: block;
+  overflow: auto;
 }
 
 pre.prettyprint, pre > code {


### PR DESCRIPTION
Hey,

Long code strings break page's layout. 

<img width="623" alt="Screenshot 2019-07-21 at 10 14 40" src="https://user-images.githubusercontent.com/3923527/61588235-82dab880-aba0-11e9-8b4a-34c80a990c4c.png">
<img width="623" alt="Screenshot 2019-07-21 at 10 14 58" src="https://user-images.githubusercontent.com/3923527/61588236-82dab880-aba0-11e9-9fd6-625eea56e223.png">


This small change fix it.