### PR TITLE
Add replaces[].fromFlags for supporting flags of regular expression

### DIFF
--- a/esdoc-importpath-plugin/README.md
+++ b/esdoc-importpath-plugin/README.md
@@ -19,7 +19,7 @@ Therefore, convert the import path by using following setting.
       "option": {
         "stripPackageName": false,
         "replaces": [
-          {"from": "^src/", "to": "lib/"}
+          {"from": "^src/", "fromFlags": "i", "to": "lib/"}
         ]
       }
     }
@@ -27,7 +27,7 @@ Therefore, convert the import path by using following setting.
 }
 ```
 
-``from`` is regular expression and ``to``is letter. In the internal ``from`` and ``to`` are used with ``String#replace(new RegExp (from), to)``.
+``from`` is regular expression, ``fromFlags`` is flags of regular expression, and ``to``is letter. In the internal ``from``, ``fromFlags`` and ``to`` are used with ``String#replace(new RegExp (from, fromFlags), to)``.
 
 When writing multi rules, it will also be carried out transformation many times.
 For example, ``[{from: "^src/", to: "lib/"}, {from: "MyFooClass", to: "my-foo"}]`` converted as follows:

--- a/esdoc-importpath-plugin/src/Plugin.js
+++ b/esdoc-importpath-plugin/src/Plugin.js
@@ -10,7 +10,7 @@ class Plugin {
     const option = ev.data.option;
 
     for (let item of option.replaces) {
-      item.from = new RegExp(item.from);
+      item.from = new RegExp(item.from, item.fromFlags);
     }
 
     // get package.json

--- a/esdoc-importpath-plugin/test/esdoc.json
+++ b/esdoc-importpath-plugin/test/esdoc.json
@@ -7,7 +7,7 @@
       "name": "./src/Plugin.js",
       "option": {
         "replaces": [
-          {"from": "^src/", "to": "lib/"},
+          {"from": "^src/", "fromFlags": "i", "to": "lib/"},
           {"from": "^lib/MyClass2.js", "to": "lib/foo"}
         ]
       }


### PR DESCRIPTION
``from`` is regular expression, ``fromFlags`` is flags of regular expression, and ``to``is letter. In the internal ``from``, ``fromFlags`` and ``to`` are used with ``String#replace(new RegExp (from, fromFlags), to)``.

```json
  "plugins": [
    {
      "name": "./src/Plugin.js",
      "option": {
        "replaces": [
          {"from": "^src/", "fromFlags": "i", "to": "lib/"},
          {"from": "^lib/MyClass2.js", "to": "lib/foo"}
        ]
      }
    }
  ]
```