### PR TITLE
fix: escape square

### DIFF
--- a/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
+++ b/esdoc-publish-html-plugin/src/Builder/DocBuilder.js
@@ -89,7 +89,7 @@ export default class DocBuilder {
     }
     if (docs.length) return docs;
 
-    const regexp = new RegExp(`[~]${name.replace('*', '\\*')}$`); // if name is `*`, need to escape.
+    const regexp = new RegExp(`[~]${name.replace('*', '\\*').replace('[', '\\[').replace(']', '\\]')}$`); // if name is `*` or `[` or `]`, need to escape.
     if (kind) {
       docs = this._orderedFind(null, {longname: {regex: regexp}, kind: kind});
     } else {


### PR DESCRIPTION
When having params like 
`[number, number]` throws error as below

![image](https://user-images.githubusercontent.com/19614770/121785343-7c65e780-cbe3-11eb-8ad9-90cf4bcf495d.png)

This PR is will fix the problem
