### PR TITLE
Add defaultAccess option to esdoc-accessor-plugin

### DIFF
--- a/esdoc-accessor-plugin/src/Plugin.js
+++ b/esdoc-accessor-plugin/src/Plugin.js
@@ -8,6 +8,7 @@ class Plugin {
     const option = ev.data.option || {};
     if (!('access' in option)) option.access = ['public', 'protected', 'private'];
     if (!('autoPrivate' in option)) option.autoPrivate = true;
+    if (!('defaultAccess' in option)) option.defaultAccess = 'public';
 
     const access = option.access;
     const autoPrivate = option.autoPrivate;
@@ -16,7 +17,7 @@ class Plugin {
         if (autoPrivate && doc.name.charAt(0) === '_') {
           doc.access = 'private';
         } else {
-          doc.access = 'public';
+          doc.access = option.defaultAccess;
         }
       }
 


### PR DESCRIPTION
To make sure some new functions/classes are not published in the documentation by mistake, it will be nice if we could define a defaultAccess property. So I can define  new functions/classes as private by default.